### PR TITLE
Rename "DUE TODAY" label to "TO REVIEW" on home screen

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -38,7 +38,7 @@ export default function HomeScreen() {
         <View style={styles.statsRow}>
           <StatCard
             value={isLoading ? "-" : String(stats.due_today)}
-            label="DUE TODAY"
+            label="TO REVIEW"
             accentColor={stats.due_today > 0
               ? AppColors.blue
               : AppColors.lightGray}


### PR DESCRIPTION
The old label implied a daily obligation. "TO REVIEW" is clearer —
it tells users these cards are ready for practice without suggesting
a deadline or required daily goal.

https://claude.ai/code/session_016T1L4oLZQv7RWxGqqpbP5D