### PR TITLE
Fix noun wrapping in quiz with tiered font sizing

### DIFF
--- a/app/quiz.tsx
+++ b/app/quiz.tsx
@@ -24,25 +24,13 @@ import {
   shadowStyleSmall,
 } from '@/constants/design';
 import { applyGermanTextPreference } from '@/utils/germanText';
+import { getNounFontSize } from '@/utils/typography';
 
 // ── Constants ────────────────────────────────────────────────────────
 
 const ARTICLES = ['der', 'die', 'das'] as const;
 type Article = (typeof ARTICLES)[number];
 const FEEDBACK_DELAY_MS = 1200;
-
-// ── Helper Functions ─────────────────────────────────────────────────
-
-/**
- * Returns appropriate font size based on word length to prevent awkward wrapping.
- * Uses tiered sizing to maintain neo-brutalist bold, consistent aesthetic.
- */
-function getNounFontSize(word: string): number {
-  const length = word.length;
-  if (length <= 12) return Typography.huge; // 48px - most words
-  if (length <= 18) return Typography.title; // 32px - longer words
-  return Typography.heading; // 24px - very long words
-}
 
 // ── Quiz Screen ──────────────────────────────────────────────────────
 

--- a/utils/typography.ts
+++ b/utils/typography.ts
@@ -1,0 +1,24 @@
+import { Typography } from '@/constants/design';
+
+/**
+ * Typography utility functions for consistent text sizing across the app.
+ */
+
+/**
+ * Returns appropriate font size based on word length to prevent awkward wrapping.
+ * Uses tiered sizing to maintain neo-brutalist bold, consistent aesthetic.
+ *
+ * @param word - The word to calculate font size for
+ * @returns Font size in pixels
+ *
+ * @example
+ * getNounFontSize('Hund') → 48 (Typography.huge)
+ * getNounFontSize('Verantwortung') → 32 (Typography.title)
+ * getNounFontSize('Geschwindigkeitsbegrenzung') → 24 (Typography.heading)
+ */
+export function getNounFontSize(word: string): number {
+  const length = word.length;
+  if (length <= 12) return Typography.huge; // 48px - most words
+  if (length <= 18) return Typography.title; // 32px - longer words
+  return Typography.heading; // 24px - very long words
+}


### PR DESCRIPTION
Implemented tiered font sizing for quiz nouns to prevent awkward wrapping:
- Words ≤12 chars: 48px (Typography.huge) - most common
- Words 13-18 chars: 32px (Typography.title) - longer words
- Words >18 chars: 24px (Typography.heading) - very long words

This approach maintains the neo-brutalist bold aesthetic while ensuring
all words remain readable and prevent just a few letters wrapping to a
second line.

https://claude.ai/code/session_01VNLSHeMTSCHLfVTWFBJFZ8