### PR TITLE
feat: add versioned noun corrections system for fixing seeded data

### DIFF
--- a/database/seed.ts
+++ b/database/seed.ts
@@ -1,5 +1,7 @@
 import type * as SQLite from 'expo-sqlite';
+import type { NounCorrection } from '@/types/database';
 import { categories } from './seeds/categories';
+import { nounCorrectionVersions } from './seeds/corrections';
 import { nounSeedVersions } from './seeds/nouns';
 
 /**
@@ -25,6 +27,9 @@ export async function seedVocabulary(db: SQLite.SQLiteDatabase): Promise<void> {
 
   // Enforce NOT NULL constraint on category_id after all nouns have categories
   await enforceNounCategoryConstraint(db, '2.0.1_noun_category_not_null');
+
+  // Apply any data corrections (wrong articles, plurals, etc.)
+  await applyNounCorrections(db);
 }
 
 /**
@@ -248,6 +253,124 @@ async function seedNounVersions(db: SQLite.SQLiteDatabase): Promise<void> {
 
     console.log(
       `[DB] Seeded nouns (${seedVersion.version}), ${seedVersion.nouns.length} entries processed`,
+    );
+  }
+}
+
+/**
+ * Apply versioned noun corrections.
+ * Unlike seeds (which preserve existing values with COALESCE), corrections
+ * force-overwrite specific fields to fix incorrect data.
+ *
+ * The noun row is updated in-place so its `id` stays the same, preserving
+ * any card_progress and review_history that reference it.
+ */
+async function applyNounCorrections(db: SQLite.SQLiteDatabase): Promise<void> {
+  if (nounCorrectionVersions.length === 0) {
+    return;
+  }
+
+  // Pre-fetch category name→ID mappings (only if any correction needs it)
+  let categoryIdMap: Map<string, number> | null = null;
+
+  for (const batch of nounCorrectionVersions) {
+    const exists = await db.getFirstAsync<{ '1': number }>(
+      'SELECT 1 FROM data_versions WHERE version = ?',
+      [batch.version],
+    );
+
+    if (exists) {
+      continue; // Already applied
+    }
+
+    console.log(
+      `[DB] Applying noun corrections (${batch.version}), ${batch.corrections.length} entries...`,
+    );
+
+    // Lazy-load category mappings on first use
+    if (!categoryIdMap) {
+      categoryIdMap = new Map<string, number>();
+      const allCategories = await db.getAllAsync<{ id: number; name: string }>(
+        'SELECT id, name FROM categories',
+      );
+      for (const cat of allCategories) {
+        categoryIdMap.set(cat.name, cat.id);
+      }
+    }
+
+    await db.withTransactionAsync(async () => {
+      for (const correction of batch.corrections) {
+        await applyNounCorrection(db, correction, categoryIdMap!);
+      }
+
+      await db.runAsync('INSERT INTO data_versions (version) VALUES (?)', [
+        batch.version,
+      ]);
+    });
+
+    console.log(
+      `[DB] Applied noun corrections (${batch.version}), ${batch.corrections.length} entries processed`,
+    );
+  }
+}
+
+/**
+ * Apply a single noun correction.
+ * Builds a dynamic UPDATE statement from the provided correction fields.
+ */
+async function applyNounCorrection(
+  db: SQLite.SQLiteDatabase,
+  correction: NounCorrection,
+  categoryIdMap: Map<string, number>,
+): Promise<void> {
+  const setClauses: string[] = [];
+  const params: (string | number | null)[] = [];
+
+  if (correction.corrections.article !== undefined) {
+    setClauses.push('article = ?');
+    params.push(correction.corrections.article);
+  }
+
+  if (correction.corrections.plural !== undefined) {
+    setClauses.push('plural = ?');
+    params.push(correction.corrections.plural);
+  }
+
+  if (correction.corrections.english !== undefined) {
+    setClauses.push('english = ?');
+    params.push(correction.corrections.english);
+  }
+
+  if (correction.corrections.category !== undefined) {
+    const categoryId = categoryIdMap.get(correction.corrections.category);
+    if (!categoryId) {
+      console.warn(
+        `[DB] Unknown category "${correction.corrections.category}" in correction for "${correction.german}", skipping`,
+      );
+      return;
+    }
+    setClauses.push('category_id = ?');
+    params.push(categoryId);
+  }
+
+  if (setClauses.length === 0) {
+    console.warn(
+      `[DB] Correction for "${correction.german}" has no fields to update, skipping`,
+    );
+    return;
+  }
+
+  // WHERE clause: match on the UNIQUE key (german, article)
+  params.push(correction.german, correction.currentArticle);
+
+  const result = await db.runAsync(
+    `UPDATE nouns SET ${setClauses.join(', ')} WHERE german = ? AND article = ?`,
+    params,
+  );
+
+  if (result.changes === 0) {
+    console.warn(
+      `[DB] Correction target not found: "${correction.currentArticle} ${correction.german}"`,
     );
   }
 }

--- a/database/seeds/corrections/corrections-example.ts
+++ b/database/seeds/corrections/corrections-example.ts
@@ -1,0 +1,48 @@
+/**
+ * Example correction file — DO NOT ship this file as-is.
+ *
+ * When a user reports incorrect data, create a real file (e.g.,
+ * `2025-02-corrections.ts`) and register it in `index.ts`.
+ *
+ * Steps to add a correction:
+ *
+ * 1. Create a file in this directory with the corrections:
+ *
+ *    // database/seeds/corrections/2025-02-corrections.ts
+ *    import type { NounCorrection } from '@/types/database';
+ *
+ *    export const feb2025Corrections: NounCorrection[] = [
+ *      {
+ *        // Fix: "der Milch" → "die Milch"
+ *        german: 'Milch',
+ *        currentArticle: 'der',
+ *        corrections: { article: 'die' },
+ *      },
+ *      {
+ *        // Fix: wrong plural for Haus
+ *        german: 'Haus',
+ *        currentArticle: 'das',
+ *        corrections: { plural: 'Häuser' },
+ *      },
+ *      {
+ *        // Fix: multiple fields at once
+ *        german: 'Stuhl',
+ *        currentArticle: 'der',
+ *        corrections: { plural: 'Stühle', english: 'chair' },
+ *      },
+ *    ];
+ *
+ * 2. Register it in `index.ts`:
+ *
+ *    import { feb2025Corrections } from './2025-02-corrections';
+ *
+ *    export const nounCorrectionVersions: NounCorrectionVersion[] = [
+ *      { version: '4.0.0_corrections_001', corrections: feb2025Corrections },
+ *    ];
+ *
+ * 3. Also fix the original seed file (e.g., v1-initial.ts) so new installs
+ *    get the correct data from the start.
+ *
+ * 4. Ship the app update. On next launch, `applyNounCorrections()` will
+ *    apply the corrections once and mark the version as done.
+ */

--- a/database/seeds/corrections/index.ts
+++ b/database/seeds/corrections/index.ts
@@ -1,0 +1,21 @@
+import type { NounCorrectionVersion } from '@/types/database';
+
+/**
+ * Registry of versioned noun corrections.
+ *
+ * Use this to fix incorrect data (wrong articles, plurals, translations) that
+ * has already been seeded to users' devices. Each version is tracked in
+ * `data_versions` and applied at most once.
+ *
+ * IMPORTANT: Also fix the original seed file so new installs get the correct
+ * data from the start. This registry only handles existing users.
+ *
+ * To add a correction:
+ * 1. Create a new file in this directory (e.g., `2025-02-corrections.ts`)
+ * 2. Import and append it here with a unique version string
+ * 3. Fix the same data in the original seed file (e.g., v1-initial.ts)
+ */
+export const nounCorrectionVersions: NounCorrectionVersion[] = [
+  // Example (uncomment and replace when needed):
+  // { version: '4.0.0_corrections_001', corrections: exampleCorrections },
+];

--- a/types/database.ts
+++ b/types/database.ts
@@ -161,6 +161,27 @@ export interface SeedCategory {
   display_order: number;
 }
 
+/** A correction to an existing noun in the database */
+export interface NounCorrection {
+  /** The German word to match (part of UNIQUE key) */
+  german: string;
+  /** The current article to match (part of UNIQUE key) */
+  currentArticle: 'der' | 'die' | 'das';
+  /** Fields to overwrite — only specify fields that need correction */
+  corrections: {
+    article?: 'der' | 'die' | 'das';
+    plural?: string | null;
+    english?: string;
+    category?: CategoryName;
+  };
+}
+
+/** A versioned batch of noun corrections */
+export interface NounCorrectionVersion {
+  version: string;
+  corrections: NounCorrection[];
+}
+
 /** Migration definition */
 export interface Migration {
   version: string;


### PR DESCRIPTION
Adds a corrections mechanism that runs after seeding to fix incorrect vocabulary data (wrong articles, plurals, etc.) on existing users' devices. Unlike seeds which preserve existing values, corrections force-overwrite specified fields while keeping the noun ID stable so card_progress and review_history are preserved.

## Summary:

- Adds a corrections mechanism that runs after seeding to fix incorrect vocabulary data (wrong articles, plurals, translations) on existing users’ devices
- Unlike seeds which preserve existing values via COALESCE, corrections force-overwrite specified fields while keeping the noun id stable so card_progress and review_history are preserved
- Each correction batch is versioned and tracked in data_versions, applied at most once per user

https://claude.ai/code/session_01FYSGMomt4eyCj63jwiWHQF