### PR TITLE
Shuffle quiz cards to prevent category clustering

### DIFF
--- a/services/spacedRepetitionService.ts
+++ b/services/spacedRepetitionService.ts
@@ -1,6 +1,18 @@
 import { getDatabase } from '@/database/db';
 import type { CardReview, DueCard, ReviewSession } from '@/types/database';
 
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Fisher-Yates shuffle — returns a new array in random order. */
+function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
 // ── SM-2 Core Algorithm ───────────────────────────────────────────────
 
 /**
@@ -238,7 +250,7 @@ export class SpacedRepetitionService {
     );
 
     return {
-      cards: [...dueCards, ...newCards],
+      cards: shuffleArray([...dueCards, ...newCards]),
       dueCount: dueCards.length,
       newCount: newCards.length,
     };


### PR DESCRIPTION
Due cards were ordered by next_review_date ASC, which caused words
learned together (same category) to reappear in clusters. Now the
combined due + new cards array is shuffled with Fisher-Yates before
being presented in the quiz session.

https://claude.ai/code/session_018XAxFkgenXS9VPsAjpK7An