### PR TITLE
feat: implement migration 004 for canonical nouns schema

### DIFF
--- a/database/__tests__/migrations.test.ts
+++ b/database/__tests__/migrations.test.ts
@@ -88,11 +88,12 @@ describe('runMigrations()', () => {
   });
 
   it('applies only unapplied migrations in a partial state', async () => {
-    // Migration 001 already applied; 002 and 003 not yet applied
+    // Migration 001 already applied; 002, 003, and 004 not yet applied
     mockDb.getFirstAsync
       .mockResolvedValueOnce({ '1': 1 }) // 001 → applied
       .mockResolvedValueOnce(null) // 002 → unapplied
-      .mockResolvedValueOnce(null); // 003 → unapplied
+      .mockResolvedValueOnce(null) // 003 → unapplied
+      .mockResolvedValueOnce(null); // 004 → unapplied
 
     await runMigrations(mockDb as any);
 
@@ -101,9 +102,10 @@ describe('runMigrations()', () => {
         sql === 'INSERT INTO migrations (version) VALUES (?)',
     );
 
-    expect(insertCalls).toHaveLength(2);
+    expect(insertCalls).toHaveLength(3);
     expect(insertCalls[0][1]).toEqual(['002']);
     expect(insertCalls[1][1]).toEqual(['003']);
+    expect(insertCalls[2][1]).toEqual(['004']);
   });
 
   it('calls each migration up() with the db object', async () => {

--- a/database/migrations.ts
+++ b/database/migrations.ts
@@ -245,6 +245,89 @@ export const migrations: Migration[] = [
       await db.execAsync('DROP INDEX IF EXISTS idx_categories_remote_id;');
     },
   },
+  {
+    version: '004',
+    name: 'canonical_nouns_schema',
+    up: async (db: SQLite.SQLiteDatabase) => {
+      console.log('[Migration 004] Rebuilding nouns table with canonical schema...');
+
+      // Fix any null category_ids before enforcing NOT NULL
+      const generalCat = await db.getFirstAsync<{ id: number }>(
+        'SELECT id FROM categories WHERE name = ?',
+        ['general'],
+      );
+      if (generalCat) {
+        await db.runAsync(
+          'UPDATE nouns SET category_id = ? WHERE category_id IS NULL',
+          [generalCat.id],
+        );
+      }
+
+      // Create the authoritative nouns table with all columns defined
+      await db.execAsync(`
+        CREATE TABLE nouns_v4 (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          german TEXT NOT NULL,
+          article TEXT NOT NULL CHECK(article IN ('der', 'die', 'das')),
+          plural TEXT,
+          english TEXT,
+          level TEXT CHECK(level IN ('A1', 'A2', 'B1', 'B2', 'C1', 'C2')),
+          category_id INTEGER NOT NULL,
+          remote_id TEXT,
+          is_user_added BOOLEAN DEFAULT 0,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(german, article),
+          FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE RESTRICT
+        );
+      `);
+
+      // Copy data — try including remote_id first; fall back if column doesn't exist
+      // (handles the edge case where migration 003 ran but then seed dropped the column)
+      try {
+        await db.execAsync(`
+          INSERT INTO nouns_v4 (id, german, article, plural, english, level, category_id, remote_id, is_user_added, created_at)
+          SELECT id, german, article, plural, english, level, category_id, remote_id, is_user_added, created_at
+          FROM nouns;
+        `);
+      } catch {
+        // remote_id column doesn't exist in source table — copy without it
+        await db.execAsync(`
+          INSERT INTO nouns_v4 (id, german, article, plural, english, level, category_id, is_user_added, created_at)
+          SELECT id, german, article, plural, english, level, category_id, is_user_added, created_at
+          FROM nouns;
+        `);
+      }
+
+      // Swap tables
+      await db.execAsync('DROP TABLE nouns;');
+      await db.execAsync('ALTER TABLE nouns_v4 RENAME TO nouns;');
+
+      // Recreate all indexes
+      await db.execAsync(
+        'CREATE INDEX IF NOT EXISTS idx_nouns_level ON nouns(level);',
+      );
+      await db.execAsync(
+        'CREATE INDEX IF NOT EXISTS idx_nouns_user_added ON nouns(is_user_added);',
+      );
+      await db.execAsync(
+        'CREATE INDEX IF NOT EXISTS idx_nouns_category ON nouns(category_id);',
+      );
+      await db.execAsync(
+        'CREATE UNIQUE INDEX IF NOT EXISTS idx_nouns_remote_id ON nouns(remote_id) WHERE remote_id IS NOT NULL;',
+      );
+
+      // Pre-mark the seeding step so enforceNounCategoryConstraint is a no-op
+      await db.runAsync(
+        'INSERT OR IGNORE INTO data_versions (version) VALUES (?)',
+        ['2.0.1_noun_category_not_null'],
+      );
+
+      console.log('[Migration 004] Complete');
+    },
+    down: async (db: SQLite.SQLiteDatabase) => {
+      await db.execAsync('DROP INDEX IF EXISTS idx_nouns_remote_id;');
+    },
+  },
 ];
 
 /**

--- a/database/seed.ts
+++ b/database/seed.ts
@@ -878,6 +878,17 @@ async function enforceNounCategoryConstraint(
     return; // Already applied
   }
 
+  // If migration 004 has run, it already handled the canonical table recreation
+  // (including remote_id) and pre-inserted this version into data_versions.
+  // This check is a safety net in case the data_versions insert was missed.
+  const migration004Applied = await db.getFirstAsync<{ '1': number }>(
+    'SELECT 1 FROM migrations WHERE version = ?',
+    ['004'],
+  );
+  if (migration004Applied) {
+    return;
+  }
+
   console.log('[DB] Enforcing NOT NULL constraint on nouns.category_id...');
 
   await db.withTransactionAsync(async () => {
@@ -904,7 +915,9 @@ async function enforceNounCategoryConstraint(
       }
     }
 
-    // Recreate nouns table with NOT NULL constraint and foreign key
+    // Recreate nouns table with NOT NULL constraint, foreign key, and remote_id.
+    // remote_id must be included here to preserve it for any install that
+    // had migration 003 applied before this seed step runs.
     await db.execAsync(`
       CREATE TABLE nouns_new (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -914,6 +927,7 @@ async function enforceNounCategoryConstraint(
         english TEXT,
         level TEXT CHECK(level IN ('A1', 'A2', 'B1', 'B2', 'C1', 'C2')),
         category_id INTEGER NOT NULL,
+        remote_id TEXT,
         is_user_added BOOLEAN DEFAULT 0,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         UNIQUE(german, article),
@@ -922,10 +936,11 @@ async function enforceNounCategoryConstraint(
     `);
 
     // Copy data with explicit column mapping (column order differs between
-    // the ALTERed table and the new definition)
+    // the ALTERed table and the new definition).
+    // remote_id is included so it is preserved across the table swap.
     await db.execAsync(`
-      INSERT INTO nouns_new (id, german, article, plural, english, level, category_id, is_user_added, created_at)
-      SELECT id, german, article, plural, english, level, category_id, is_user_added, created_at
+      INSERT INTO nouns_new (id, german, article, plural, english, level, category_id, remote_id, is_user_added, created_at)
+      SELECT id, german, article, plural, english, level, category_id, remote_id, is_user_added, created_at
       FROM nouns;
     `);
 
@@ -942,6 +957,9 @@ async function enforceNounCategoryConstraint(
     );
     await db.execAsync(
       'CREATE INDEX IF NOT EXISTS idx_nouns_category ON nouns(category_id);',
+    );
+    await db.execAsync(
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_nouns_remote_id ON nouns(remote_id) WHERE remote_id IS NOT NULL;',
     );
 
     // Mark as applied


### PR DESCRIPTION
- Added migration 004 to rebuild the nouns table with a canonical schema, enforcing NOT NULL constraints on category_id and including remote_id.
- Implemented data copying with error handling for remote_id presence.
- Updated seed logic to check for migration 004 application before enforcing constraints.
- Enhanced tests to account for the new migration state.