### PR TITLE
feat: add progress tab with stats, activity heatmap, and hardest words

### DIFF
--- a/app/(tabs)/_layout.ios.tsx
+++ b/app/(tabs)/_layout.ios.tsx
@@ -9,6 +9,10 @@ export default function TabLayout() {
         <Label>{t('practice')}</Label>
         <Icon sf={{ default: 'book', selected: 'book.fill' }} />
       </NativeTabs.Trigger>
+      <NativeTabs.Trigger name="progress">
+        <Label>{t('progress_screen.tab_label')}</Label>
+        <Icon sf={{ default: 'chart.bar', selected: 'chart.bar.fill' }} />
+      </NativeTabs.Trigger>
       <NativeTabs.Trigger name="explore">
         <Label>{t('about')}</Label>
         <Icon sf={{ default: 'info.circle', selected: 'info.circle.fill' }} />

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -35,6 +35,18 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="progress"
+        options={{
+          title: t('progress_screen.tab_label').toUpperCase(),
+          tabBarIcon: ({ color, focused }) => (
+            <View style={styles.iconContainer}>
+              <IconSymbol size={26} name="chart.bar.fill" color={color} />
+              {focused && <View style={styles.activeIndicator} />}
+            </View>
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="explore"
         options={{
           title: t('about').toUpperCase(),

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,0 +1,660 @@
+import {
+  AppColors,
+  Layout,
+  shadowStyle,
+  shadowStyleSmall,
+  Spacing,
+  Typography,
+} from '@/constants/design';
+import { useProgressData } from '@/hooks/use-progress-data';
+import type { DailyActivity, HardWord } from '@/services/statisticsService';
+import { useTranslation } from 'react-i18next';
+import { useMemo } from 'react';
+import {
+  Dimensions,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+// ── Heatmap constants ────────────────────────────────────────────────
+
+const NUM_WEEKS = 13; // ~3 months of history
+const CELL_GAP = 3;
+const DAY_LABEL_WIDTH = 12;
+const DAY_LABEL_GAP = 6;
+const SCREEN_PADDING = Layout.screenPadding;
+const CARD_PADDING = Layout.cardPadding;
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const AVAILABLE_FOR_GRID =
+  SCREEN_WIDTH -
+  SCREEN_PADDING * 2 - // screen-level padding
+  CARD_PADDING * 2 - // card padding
+  DAY_LABEL_WIDTH -
+  DAY_LABEL_GAP -
+  CELL_GAP * (NUM_WEEKS - 1);
+
+const CELL_SIZE = Math.max(
+  14,
+  Math.floor(AVAILABLE_FOR_GRID / NUM_WEEKS),
+);
+
+// Day abbreviations indexed Mon=0 … Sun=6
+const DAY_ABBREVS = ['M', '', 'W', '', 'F', '', 'S'];
+
+const MONTH_ABBREVS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+// ── Heatmap helpers ──────────────────────────────────────────────────
+
+interface HeatmapCell {
+  date: string; // YYYY-MM-DD
+  count: number; // -1 = future (greyed out differently)
+}
+
+/** Build a 13-column × 7-row grid, Mon-first, newest column on the right. */
+function buildHeatmapGrid(activityData: DailyActivity[]): HeatmapCell[][] {
+  const activityMap = new Map<string, number>();
+  activityData.forEach(d => activityMap.set(d.date, d.count));
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // Find the Monday of this week
+  const dow = today.getDay(); // 0=Sun
+  const daysToMonday = dow === 0 ? 6 : dow - 1;
+  const thisMonday = new Date(today);
+  thisMonday.setDate(thisMonday.getDate() - daysToMonday);
+
+  // Start date = Monday 12 weeks before this week
+  const startDate = new Date(thisMonday);
+  startDate.setDate(startDate.getDate() - (NUM_WEEKS - 1) * 7);
+
+  const grid: HeatmapCell[][] = [];
+  for (let week = 0; week < NUM_WEEKS; week++) {
+    const weekCells: HeatmapCell[] = [];
+    for (let day = 0; day < 7; day++) {
+      const cellDate = new Date(startDate);
+      cellDate.setDate(cellDate.getDate() + week * 7 + day);
+      const dateStr = cellDate.toISOString().split('T')[0];
+      const isFuture = cellDate > today;
+      weekCells.push({
+        date: dateStr,
+        count: isFuture ? -1 : (activityMap.get(dateStr) ?? 0),
+      });
+    }
+    grid.push(weekCells);
+  }
+
+  return grid;
+}
+
+/** Map a review count to a background color. */
+function getCellColor(count: number): string {
+  if (count < 0) return AppColors.lightGray; // future
+  if (count === 0) return '#E8E8E8'; // no reviews
+  if (count <= 2) return '#B3EDCE'; // light green
+  if (count <= 5) return '#4DB87A'; // medium green
+  return AppColors.green; // heavy activity
+}
+
+/** Get the month abbreviation for a given YYYY-MM-DD date string. */
+function getMonthAbbrev(dateStr: string): string {
+  const month = parseInt(dateStr.split('-')[1], 10) - 1;
+  return MONTH_ABBREVS[month] ?? '';
+}
+
+// ── Article color helper ─────────────────────────────────────────────
+
+function getArticleColor(article: string): string {
+  if (article === 'der') return AppColors.blue;
+  if (article === 'die') return AppColors.red;
+  return AppColors.green; // das
+}
+
+// ── Sub-components ───────────────────────────────────────────────────
+
+interface OverviewStatProps {
+  value: string;
+  label: string;
+  accentColor: string;
+}
+
+function OverviewStat({ value, label, accentColor }: OverviewStatProps) {
+  return (
+    <View style={[styles.overviewStat, shadowStyleSmall]}>
+      <View style={[styles.overviewAccent, { backgroundColor: accentColor }]} />
+      <Text style={styles.overviewValue}>{value}</Text>
+      <Text style={styles.overviewLabel}>{label}</Text>
+    </View>
+  );
+}
+
+// ── Heatmap section ──────────────────────────────────────────────────
+
+interface HeatmapSectionProps {
+  activityData: DailyActivity[];
+}
+
+function HeatmapSection({ activityData }: HeatmapSectionProps) {
+  const { t } = useTranslation('app');
+  const grid = useMemo(() => buildHeatmapGrid(activityData), [activityData]);
+
+  // Derive month labels: show abbreviation in first week of a new month
+  const monthLabels = useMemo(() => {
+    return grid.map((weekCells, weekIdx) => {
+      const firstDayOfWeek = weekCells[0].date;
+      const isFirstWeek = weekIdx === 0;
+      const prevWeekFirst = weekIdx > 0 ? grid[weekIdx - 1][0].date : null;
+      const currentMonth = firstDayOfWeek.split('-')[1];
+      const prevMonth = prevWeekFirst?.split('-')[1];
+      const showLabel = isFirstWeek || currentMonth !== prevMonth;
+      return showLabel ? getMonthAbbrev(firstDayOfWeek) : '';
+    });
+  }, [grid]);
+
+  return (
+    <View style={[styles.card, shadowStyle]}>
+      <Text style={styles.cardTitle}>
+        {t('progress_screen.activity_title').toUpperCase()}
+      </Text>
+      <Text style={styles.cardSubtitle}>
+        {t('progress_screen.activity_subtitle').toUpperCase()}
+      </Text>
+
+      {/* Month labels row */}
+      <View style={styles.heatmapOuter}>
+        {/* Spacer for day labels column */}
+        <View style={{ width: DAY_LABEL_WIDTH + DAY_LABEL_GAP }} />
+        <View style={styles.monthLabelsRow}>
+          {monthLabels.map((label, idx) => (
+            <View key={idx} style={styles.monthLabelCell}>
+              <Text style={styles.monthLabelText}>{label}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+
+      {/* Heatmap grid */}
+      <View style={styles.heatmapOuter}>
+        {/* Day of week labels */}
+        <View style={[styles.dayLabelsColumn, { marginRight: DAY_LABEL_GAP }]}>
+          {DAY_ABBREVS.map((abbrev, i) => (
+            <View key={i} style={[styles.dayLabelCell, { height: CELL_SIZE }]}>
+              <Text style={styles.dayLabelText}>{abbrev}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Grid: weeks as columns, days as rows */}
+        <View style={styles.heatmapGrid}>
+          {grid.map((weekCells, weekIdx) => (
+            <View key={weekIdx} style={styles.weekColumn}>
+              {weekCells.map((cell, dayIdx) => (
+                <View
+                  key={dayIdx}
+                  style={[
+                    styles.heatmapCell,
+                    {
+                      width: CELL_SIZE,
+                      height: CELL_SIZE,
+                      backgroundColor: getCellColor(cell.count),
+                    },
+                  ]}
+                />
+              ))}
+            </View>
+          ))}
+        </View>
+      </View>
+
+      {/* Legend */}
+      <View style={styles.legendRow}>
+        <Text style={styles.legendLabel}>
+          {t('progress_screen.legend_less').toUpperCase()}
+        </Text>
+        {['#E8E8E8', '#B3EDCE', '#4DB87A', AppColors.green].map((color, i) => (
+          <View
+            key={i}
+            style={[styles.legendCell, { backgroundColor: color }]}
+          />
+        ))}
+        <Text style={styles.legendLabel}>
+          {t('progress_screen.legend_more').toUpperCase()}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+// ── Hardest words section ────────────────────────────────────────────
+
+interface HardestWordsSectionProps {
+  words: HardWord[];
+}
+
+function HardestWordsSection({ words }: HardestWordsSectionProps) {
+  const { t } = useTranslation('app');
+
+  return (
+    <View style={[styles.card, shadowStyle]}>
+      <Text style={styles.cardTitle}>
+        {t('progress_screen.hardest_words_title').toUpperCase()}
+      </Text>
+      <Text style={styles.cardSubtitle}>
+        {t('progress_screen.hardest_words_subtitle').toUpperCase()}
+      </Text>
+
+      {words.length === 0 ? (
+        <Text style={styles.emptyText}>
+          {t('progress_screen.hardest_words_empty')}
+        </Text>
+      ) : (
+        words.map((word, idx) => {
+          const rate = word.success_rate ?? 0;
+          const articleColor = getArticleColor(word.article);
+          return (
+            <View
+              key={`${word.german}-${idx}`}
+              style={[
+                styles.hardWordRow,
+                idx < words.length - 1 && styles.hardWordRowBorder,
+              ]}
+            >
+              {/* Article badge */}
+              <View
+                style={[styles.articleBadge, { backgroundColor: articleColor }]}
+              >
+                <Text style={styles.articleBadgeText}>
+                  {word.article.toUpperCase()}
+                </Text>
+              </View>
+
+              {/* Word info */}
+              <View style={styles.wordInfo}>
+                <View style={styles.wordNameRow}>
+                  <Text style={styles.germanWord}>{word.german}</Text>
+                  {word.english ? (
+                    <Text style={styles.englishWord}>{word.english}</Text>
+                  ) : null}
+                </View>
+
+                {/* Success rate bar */}
+                <View style={styles.rateBarOuter}>
+                  <View
+                    style={[
+                      styles.rateBarFill,
+                      {
+                        width: `${rate}%`,
+                        backgroundColor:
+                          rate < 50 ? AppColors.red : AppColors.yellow,
+                      },
+                    ]}
+                  />
+                </View>
+
+                <Text style={styles.rateText}>
+                  {t('progress_screen.success_rate', {
+                    rate: Math.round(rate),
+                    count: word.total_reviews,
+                  })}
+                </Text>
+              </View>
+            </View>
+          );
+        })
+      )}
+    </View>
+  );
+}
+
+// ── Main screen ──────────────────────────────────────────────────────
+
+export default function ProgressScreen() {
+  const { t } = useTranslation('app');
+  const {
+    stats,
+    streak,
+    longestStreak,
+    masteredCount,
+    activityData,
+    hardestWords,
+    isLoading,
+  } = useProgressData();
+
+  const accuracyText =
+    stats.success_rate != null
+      ? `${Math.round(stats.success_rate)}%`
+      : '--';
+
+  const hasAnyData = stats.total_reviews > 0;
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── Header ──────────────────────────────────────────── */}
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>
+            {t('progress_screen.title').toUpperCase()}
+          </Text>
+          <Text style={styles.headerSubtitle}>
+            {t('progress_screen.subtitle').toUpperCase()}
+          </Text>
+        </View>
+
+        {/* ── Stats Overview ───────────────────────────────────── */}
+        <View style={styles.overviewGrid}>
+          <OverviewStat
+            value={isLoading ? '-' : String(stats.total_reviews)}
+            label={t('progress_screen.total_reviews').toUpperCase()}
+            accentColor={AppColors.blue}
+          />
+          <OverviewStat
+            value={isLoading ? '-' : accuracyText}
+            label={t('progress_screen.accuracy').toUpperCase()}
+            accentColor={
+              stats.success_rate != null ? AppColors.green : AppColors.lightGray
+            }
+          />
+          <OverviewStat
+            value={isLoading ? '-' : String(stats.total_cards)}
+            label={t('progress_screen.words_started').toUpperCase()}
+            accentColor={AppColors.yellow}
+          />
+          <OverviewStat
+            value={isLoading ? '-' : String(streak)}
+            label={t('progress_screen.current_streak').toUpperCase()}
+            accentColor={streak > 0 ? AppColors.yellow : AppColors.lightGray}
+          />
+          <OverviewStat
+            value={isLoading ? '-' : String(longestStreak)}
+            label={t('progress_screen.longest_streak').toUpperCase()}
+            accentColor={longestStreak > 0 ? AppColors.purple : AppColors.lightGray}
+          />
+          <OverviewStat
+            value={isLoading ? '-' : String(masteredCount)}
+            label={t('progress_screen.mastered').toUpperCase()}
+            accentColor={masteredCount > 0 ? AppColors.green : AppColors.lightGray}
+          />
+        </View>
+
+        {/* ── Activity Heatmap ─────────────────────────────────── */}
+        {!isLoading && (
+          <HeatmapSection activityData={activityData} />
+        )}
+
+        {/* ── Hardest Words ────────────────────────────────────── */}
+        {!isLoading && hasAnyData && (
+          <HardestWordsSection words={hardestWords} />
+        )}
+
+        {/* ── Empty state ───────────────────────────────────────── */}
+        {!isLoading && !hasAnyData && (
+          <View style={[styles.emptyCard, shadowStyleSmall]}>
+            <Text style={styles.emptyCardText}>
+              {t('progress_screen.no_data')}
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+// ── Styles ───────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: AppColors.cream,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: Layout.screenPadding,
+    paddingBottom: Spacing.xxl,
+  },
+
+  // ── Header
+  header: {
+    borderBottomWidth: Layout.borderWidth,
+    borderBottomColor: AppColors.black,
+    paddingBottom: Spacing.md,
+    marginBottom: Spacing.lg,
+  },
+  headerTitle: {
+    fontSize: Typography.title,
+    fontWeight: Typography.bold,
+    color: AppColors.black,
+    letterSpacing: 1,
+  },
+  headerSubtitle: {
+    fontSize: Typography.small,
+    fontWeight: Typography.semibold,
+    color: AppColors.textSecondary,
+    letterSpacing: 2,
+    marginTop: Spacing.xs,
+  },
+
+  // ── Overview stats grid (2 rows × 3 cols)
+  overviewGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+    marginBottom: Spacing.lg,
+  },
+  overviewStat: {
+    width: '30.5%', // 3 per row with gap
+    backgroundColor: AppColors.white,
+    borderWidth: Layout.borderWidth,
+    borderColor: AppColors.black,
+    paddingTop: Spacing.sm + 6, // extra top for accent strip
+    paddingBottom: Spacing.md,
+    paddingHorizontal: Spacing.xs,
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  overviewAccent: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 6,
+  },
+  overviewValue: {
+    fontSize: Typography.heading,
+    fontWeight: Typography.bold,
+    color: AppColors.black,
+    textAlign: 'center',
+  },
+  overviewLabel: {
+    fontSize: 10,
+    fontWeight: Typography.semibold,
+    color: AppColors.textSecondary,
+    textAlign: 'center',
+    letterSpacing: 0.5,
+    marginTop: Spacing.xs,
+  },
+
+  // ── Shared card shell
+  card: {
+    backgroundColor: AppColors.white,
+    borderWidth: Layout.borderWidth,
+    borderColor: AppColors.black,
+    padding: Layout.cardPadding,
+    marginBottom: Spacing.lg,
+  },
+  cardTitle: {
+    fontSize: Typography.small,
+    fontWeight: Typography.bold,
+    color: AppColors.black,
+    letterSpacing: 1.5,
+    marginBottom: Spacing.xs,
+  },
+  cardSubtitle: {
+    fontSize: Typography.tiny,
+    fontWeight: Typography.semibold,
+    color: AppColors.textSecondary,
+    letterSpacing: 1,
+    marginBottom: Spacing.md,
+  },
+
+  // ── Heatmap
+  heatmapOuter: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+  monthLabelsRow: {
+    flexDirection: 'row',
+    gap: CELL_GAP,
+    marginBottom: Spacing.xs,
+  },
+  monthLabelCell: {
+    width: CELL_SIZE,
+    alignItems: 'flex-start',
+  },
+  monthLabelText: {
+    fontSize: 9,
+    fontWeight: Typography.semibold,
+    color: AppColors.textSecondary,
+    letterSpacing: 0.5,
+  },
+  dayLabelsColumn: {
+    width: DAY_LABEL_WIDTH,
+    gap: CELL_GAP,
+  },
+  dayLabelCell: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  dayLabelText: {
+    fontSize: 9,
+    fontWeight: Typography.semibold,
+    color: AppColors.textSecondary,
+  },
+  heatmapGrid: {
+    flexDirection: 'row',
+    gap: CELL_GAP,
+  },
+  weekColumn: {
+    flexDirection: 'column',
+    gap: CELL_GAP,
+  },
+  heatmapCell: {
+    // width and height are set inline (computed from screen width)
+    borderRadius: 2,
+  },
+
+  // Legend
+  legendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    marginTop: Spacing.md,
+  },
+  legendLabel: {
+    fontSize: 9,
+    fontWeight: Typography.semibold,
+    color: AppColors.textSecondary,
+    letterSpacing: 0.5,
+  },
+  legendCell: {
+    width: 12,
+    height: 12,
+    borderRadius: 2,
+  },
+
+  // ── Hardest words
+  hardWordRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.md,
+    gap: Spacing.sm,
+  },
+  hardWordRowBorder: {
+    borderBottomWidth: Layout.borderWidthThin,
+    borderBottomColor: AppColors.lightGray,
+  },
+  articleBadge: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xs,
+    borderWidth: Layout.borderWidthThin,
+    borderColor: AppColors.black,
+    minWidth: 40,
+    alignItems: 'center',
+  },
+  articleBadgeText: {
+    fontSize: Typography.tiny,
+    fontWeight: Typography.bold,
+    color: AppColors.white,
+    letterSpacing: 0.5,
+  },
+  wordInfo: {
+    flex: 1,
+  },
+  wordNameRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: Spacing.sm,
+    marginBottom: Spacing.xs,
+  },
+  germanWord: {
+    fontSize: Typography.body,
+    fontWeight: Typography.bold,
+    color: AppColors.black,
+  },
+  englishWord: {
+    fontSize: Typography.small,
+    fontWeight: Typography.regular,
+    color: AppColors.textSecondary,
+  },
+  rateBarOuter: {
+    height: 8,
+    backgroundColor: AppColors.lightGray,
+    borderWidth: 1,
+    borderColor: AppColors.black,
+    overflow: 'hidden',
+    marginBottom: Spacing.xs,
+  },
+  rateBarFill: {
+    height: '100%',
+  },
+  rateText: {
+    fontSize: Typography.tiny,
+    fontWeight: Typography.semibold,
+    color: AppColors.textSecondary,
+    letterSpacing: 0.5,
+  },
+  emptyText: {
+    fontSize: Typography.small,
+    fontWeight: Typography.regular,
+    color: AppColors.textSecondary,
+    lineHeight: 20,
+    marginTop: Spacing.xs,
+  },
+
+  // ── Empty state card
+  emptyCard: {
+    backgroundColor: AppColors.white,
+    borderWidth: Layout.borderWidth,
+    borderColor: AppColors.black,
+    padding: Layout.cardPadding,
+  },
+  emptyCardText: {
+    fontSize: Typography.body,
+    fontWeight: Typography.regular,
+    color: AppColors.textSecondary,
+    lineHeight: 24,
+    textAlign: 'center',
+  },
+});

--- a/hooks/use-progress-data.ts
+++ b/hooks/use-progress-data.ts
@@ -1,0 +1,103 @@
+import { useCallback, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import { spacedRepetitionService } from '@/services/spacedRepetitionService';
+import {
+  statisticsService,
+  type DailyActivity,
+  type HardWord,
+} from '@/services/statisticsService';
+import { vocabularyService } from '@/services/vocabularyService';
+import type { UserStats } from '@/types/database';
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface ProgressData {
+  stats: UserStats;
+  streak: number;
+  longestStreak: number;
+  masteredCount: number;
+  activityData: DailyActivity[];
+  hardestWords: HardWord[];
+  isLoading: boolean;
+}
+
+const defaultStats: UserStats = {
+  total_cards: 0,
+  total_reviews: 0,
+  correct_reviews: 0,
+  success_rate: null,
+  due_today: 0,
+};
+
+// ── Hook ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetches all data needed for the progress screen.
+ * Re-fetches every time the screen gains focus so stats stay current.
+ */
+export function useProgressData(): ProgressData {
+  const [stats, setStats] = useState<UserStats>(defaultStats);
+  const [streak, setStreak] = useState(0);
+  const [longestStreak, setLongestStreak] = useState(0);
+  const [masteredCount, setMasteredCount] = useState(0);
+  const [activityData, setActivityData] = useState<DailyActivity[]>([]);
+  const [hardestWords, setHardestWords] = useState<HardWord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+
+      async function load() {
+        try {
+          const [
+            fetchedStats,
+            fetchedStreak,
+            fetchedLongest,
+            fetchedMastered,
+            fetchedActivity,
+            fetchedHardest,
+          ] = await Promise.all([
+            vocabularyService.getUserStats(),
+            spacedRepetitionService.getStudyStreak(),
+            statisticsService.getLongestStreak(),
+            statisticsService.getMasteredCount(),
+            statisticsService.getActivityData(91),
+            statisticsService.getHardestWords(3, 8),
+          ]);
+
+          if (!cancelled) {
+            setStats(fetchedStats);
+            setStreak(fetchedStreak);
+            setLongestStreak(fetchedLongest);
+            setMasteredCount(fetchedMastered);
+            setActivityData(fetchedActivity);
+            setHardestWords(fetchedHardest);
+          }
+        } catch (error) {
+          console.error('[ProgressData] Failed to load:', error);
+        } finally {
+          if (!cancelled) {
+            setIsLoading(false);
+          }
+        }
+      }
+
+      load();
+
+      return () => {
+        cancelled = true;
+      };
+    }, []),
+  );
+
+  return {
+    stats,
+    streak,
+    longestStreak,
+    masteredCount,
+    activityData,
+    hardestWords,
+    isLoading,
+  };
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -59,6 +59,26 @@
       "start_categories_one": "$t(categories.start) {{count}} category",
       "start_categories_other": "$t(categories.start) {{count}} categories"
     },
+    "progress_screen": {
+      "tab_label": "Progress",
+      "title": "Progress",
+      "subtitle": "Your learning journey",
+      "total_reviews": "Total Reviews",
+      "accuracy": "Accuracy",
+      "words_started": "Words Started",
+      "current_streak": "Streak",
+      "longest_streak": "Best Streak",
+      "mastered": "Mastered",
+      "activity_title": "Activity",
+      "activity_subtitle": "Last 13 weeks",
+      "legend_less": "Less",
+      "legend_more": "More",
+      "hardest_words_title": "Hardest Words",
+      "hardest_words_subtitle": "Words you miss most often",
+      "hardest_words_empty": "Practice a word at least 3 times to see your toughest ones here.",
+      "success_rate": "{{rate}}% correct ({{count}} reviews)",
+      "no_data": "Complete your first practice session to see your stats here."
+    },
     "how_it_works": {
       "title": "How It Works",
       "subtitle": "Science-backed learning",

--- a/locales/it.json
+++ b/locales/it.json
@@ -59,6 +59,26 @@
       "start_categories_one": "$t(categories.start) {{count}} categoria",
       "start_categories_other": "$t(categories.start) {{count}} categorie"
     },
+    "progress_screen": {
+      "tab_label": "Progressi",
+      "title": "Progressi",
+      "subtitle": "Il tuo percorso di apprendimento",
+      "total_reviews": "Ripetizioni totali",
+      "accuracy": "Precisione",
+      "words_started": "Parole iniziate",
+      "current_streak": "Serie",
+      "longest_streak": "Serie record",
+      "mastered": "Padroneggiato",
+      "activity_title": "Attività",
+      "activity_subtitle": "Ultime 13 settimane",
+      "legend_less": "Meno",
+      "legend_more": "Di più",
+      "hardest_words_title": "Parole difficili",
+      "hardest_words_subtitle": "Parole che sbagli più spesso",
+      "hardest_words_empty": "Esercitati su una parola almeno 3 volte per vedere quelle più difficili qui.",
+      "success_rate": "{{rate}}% corretto ({{count}} ripetizioni)",
+      "no_data": "Completa la tua prima sessione di pratica per vedere le tue statistiche qui."
+    },
     "how_it_works": {
       "title": "Come Funziona",
       "subtitle": "Apprendimento basato sulla scienza",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -67,6 +67,26 @@
       "start_categories_many": "$t(categories.start) {{count}} kategorii",
       "start_categories_other": "$t(categories.start) {{count}} kategorii"
     },
+    "progress_screen": {
+      "tab_label": "Postęp",
+      "title": "Postęp",
+      "subtitle": "Twoja droga nauki",
+      "total_reviews": "Łączne powtórzenia",
+      "accuracy": "Dokładność",
+      "words_started": "Słowa rozpoczęte",
+      "current_streak": "Seria",
+      "longest_streak": "Najlepsza seria",
+      "mastered": "Opanowane",
+      "activity_title": "Aktywność",
+      "activity_subtitle": "Ostatnie 13 tygodni",
+      "legend_less": "Mniej",
+      "legend_more": "Więcej",
+      "hardest_words_title": "Trudne słowa",
+      "hardest_words_subtitle": "Słowa, które mylisz najczęściej",
+      "hardest_words_empty": "Ćwicz słowo co najmniej 3 razy, aby zobaczyć tu najtrudniejsze.",
+      "success_rate": "{{rate}}% poprawnie ({{count}} powtórzeń)",
+      "no_data": "Ukończ pierwszą sesję ćwiczeń, aby zobaczyć tu swoje statystyki."
+    },
     "how_it_works": {
       "title": "Jak to działa",
       "subtitle": "Nauka oparta na nauce",

--- a/services/statisticsService.ts
+++ b/services/statisticsService.ts
@@ -1,0 +1,122 @@
+import { getDatabase } from '@/database/db';
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+/** Daily review count for the activity heatmap */
+export interface DailyActivity {
+  date: string; // YYYY-MM-DD
+  count: number;
+}
+
+/** A word with a low success rate — shown in the "hardest words" section */
+export interface HardWord {
+  german: string;
+  article: 'der' | 'die' | 'das';
+  english: string | null;
+  total_reviews: number;
+  correct_reviews: number;
+  success_rate: number | null;
+}
+
+// ── Service ───────────────────────────────────────────────────────────
+
+/**
+ * Service for aggregated statistics queries used on the progress screen.
+ * Keeps analytics logic separate from core vocabulary/spaced-repetition services.
+ */
+export class StatisticsService {
+  private get db() {
+    return getDatabase();
+  }
+
+  /**
+   * Get daily review counts for the last N days.
+   * Only returns days that had at least one review — caller must fill gaps.
+   */
+  async getActivityData(days: number = 91): Promise<DailyActivity[]> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    const cutoffStr = cutoff.toISOString().split('T')[0]; // YYYY-MM-DD
+
+    return await this.db.getAllAsync<DailyActivity>(
+      `SELECT date(reviewed_at) AS date, COUNT(*) AS count
+       FROM review_history
+       WHERE date(reviewed_at) >= ?
+       GROUP BY date(reviewed_at)
+       ORDER BY date ASC`,
+      [cutoffStr],
+    );
+  }
+
+  /**
+   * Get the words with the lowest success rates.
+   * Only includes cards with at least `minReviews` total reviews to avoid noise.
+   */
+  async getHardestWords(
+    minReviews: number = 3,
+    limit: number = 8,
+  ): Promise<HardWord[]> {
+    return await this.db.getAllAsync<HardWord>(
+      `SELECT
+         n.german,
+         n.article,
+         n.english,
+         cp.total_reviews,
+         cp.correct_reviews,
+         ROUND(100.0 * cp.correct_reviews / NULLIF(cp.total_reviews, 0), 1) AS success_rate
+       FROM card_progress cp
+       JOIN nouns n ON cp.word_type = 'noun' AND cp.word_id = n.id
+       WHERE cp.total_reviews >= ?
+       ORDER BY success_rate ASC, cp.total_reviews DESC
+       LIMIT ?`,
+      [minReviews, limit],
+    );
+  }
+
+  /**
+   * Count words considered "mastered" — interval of at least 21 days means
+   * the card is solidly in long-term memory.
+   */
+  async getMasteredCount(): Promise<number> {
+    const result = await this.db.getFirstAsync<{ count: number }>(
+      `SELECT COUNT(*) AS count FROM card_progress WHERE interval >= 21`,
+    );
+    return result?.count ?? 0;
+  }
+
+  /**
+   * Compute the user's all-time longest study streak (in days).
+   * Iterates over all distinct review dates in ascending order.
+   */
+  async getLongestStreak(): Promise<number> {
+    const reviews = await this.db.getAllAsync<{ review_date: string }>(
+      `SELECT DISTINCT date(reviewed_at) AS review_date
+       FROM review_history
+       ORDER BY review_date ASC`,
+    );
+
+    if (reviews.length === 0) return 0;
+
+    let longest = 1;
+    let current = 1;
+
+    for (let i = 1; i < reviews.length; i++) {
+      const prev = new Date(reviews[i - 1].review_date);
+      const curr = new Date(reviews[i].review_date);
+      const diffMs = curr.getTime() - prev.getTime();
+      const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+      if (diffDays === 1) {
+        current++;
+        if (current > longest) longest = current;
+      } else {
+        current = 1;
+      }
+    }
+
+    return longest;
+  }
+}
+
+/** Singleton instance for use across the app */
+export const statisticsService = new StatisticsService();


### PR DESCRIPTION
- New progress.tsx screen with three sections:
  - Stats overview: 6-card grid (total reviews, accuracy, words started,
    current streak, best streak, mastered words)
  - Activity heatmap: GitHub-style 13-week calendar showing daily review
    intensity with colour-coded cells (green gradient)
  - Hardest words: list of words with lowest success rates (≥3 reviews),
    each showing article badge, name, mini progress bar, and accuracy

- statisticsService.ts: new service with getActivityData (daily review
  counts), getHardestWords (lowest success rate), getMasteredCount
  (interval ≥ 21 days), and getLongestStreak (all-time best streak)

- use-progress-data.ts: focus-aware hook that fetches all progress screen
  data in parallel and refreshes whenever the tab is visited

- Tab layouts updated (both _layout.tsx and _layout.ios.tsx) to add the
  progress tab between Practice and About using chart.bar icon

- Translation keys added to en.json, it.json, and pl.json

https://claude.ai/code/session_01Suety8a3ENu6jdyykQJgTq