### PR TITLE
feat: add hard-words drill mode for struggling articles

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -22,6 +22,7 @@ export default function HomeScreen() {
     userNounCount,
     streak,
     hasReviewedToday,
+    strugglingCount,
     isLoading,
   } = useHomeData();
 
@@ -129,6 +130,31 @@ export default function HomeScreen() {
             </Pressable>
           )}
         </View>
+
+        {/* ── Struggling Words ─────────────────────────────────── */}
+        {!isLoading && strugglingCount > 0 && (
+          <Pressable
+            style={({ pressed }) => [
+              styles.strugglingButton,
+              shadowStyleSmall,
+              pressed && styles.strugglingButtonPressed,
+            ]}
+            onPress={() => router.push('/quiz?mode=struggling')}
+            accessibilityRole="button"
+            accessibilityLabel={t('struggling_words_button', {
+              count: strugglingCount,
+            })}
+          >
+            <View style={styles.strugglingButtonInner}>
+              <Text style={styles.strugglingButtonText}>
+                {t('struggling_words_button', { count: strugglingCount }).toUpperCase()}
+              </Text>
+              <Text style={styles.strugglingButtonSub}>
+                {t('struggling_words_label')}
+              </Text>
+            </View>
+          </Pressable>
+        )}
 
         {/* ── Progress Card ───────────────────────────────────── */}
         <View style={styles.progressCard}>
@@ -369,6 +395,39 @@ const styles = StyleSheet.create({
     fontWeight: Typography.bold,
     color: AppColors.black,
     letterSpacing: 1,
+  },
+
+  // Struggling Words Button
+  strugglingButton: {
+    backgroundColor: AppColors.red,
+    borderWidth: Layout.borderWidth,
+    borderColor: AppColors.black,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    marginBottom: Spacing.xl,
+  },
+  strugglingButtonPressed: {
+    transform: [{ translateY: 2 }],
+    shadowOffset: { width: 2, height: 2 },
+  },
+  strugglingButtonInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  strugglingButtonText: {
+    fontSize: Typography.small,
+    fontWeight: Typography.bold,
+    color: AppColors.white,
+    letterSpacing: 1,
+    flex: 1,
+  },
+  strugglingButtonSub: {
+    fontSize: Typography.tiny,
+    fontWeight: Typography.semibold,
+    color: AppColors.white,
+    opacity: 0.85,
+    letterSpacing: 0.5,
   },
 
   // Progress Card

--- a/app/quiz.tsx
+++ b/app/quiz.tsx
@@ -7,12 +7,16 @@ import {
   shadowStyleSmall,
 } from '@/constants/design';
 import { useNounTranslation } from '@/hooks/use-noun-translation';
-import { useQuizSession, type QuizResult } from '@/hooks/use-quiz-session';
+import {
+  useQuizSession,
+  type QuizMode,
+  type QuizResult,
+} from '@/hooks/use-quiz-session';
 import { useSettings } from '@/hooks/use-settings';
 import { applyGermanTextPreference } from '@/utils/germanText';
 import { getNounFontSize } from '@/utils/typography';
 import * as Haptics from 'expo-haptics';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { TFunction } from 'i18next';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,7 +40,8 @@ const FEEDBACK_DELAY_MS = 1200;
 
 export default function QuizScreen() {
   const { t } = useTranslation('app');
-  const quiz = useQuizSession();
+  const { mode } = useLocalSearchParams<{ mode?: QuizMode }>();
+  const quiz = useQuizSession(mode ?? 'daily');
   const { phase, nextCard, results } = quiz;
   const { showEnglishHint, eszettPreference } = useSettings();
 
@@ -54,7 +59,7 @@ export default function QuizScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       {phase === 'loading' && <LoadingState t={t} />}
-      {phase === 'empty' && <EmptyState t={t} />}
+      {phase === 'empty' && <EmptyState t={t} mode={quiz.mode} />}
       {(phase === 'playing' || phase === 'feedback') && (
         <PlayingState
           quiz={quiz}
@@ -82,15 +87,20 @@ function LoadingState({ t }: { t: TFunction }) {
 
 // ── Empty State ──────────────────────────────────────────────────────
 
-function EmptyState({ t }: { t: TFunction }) {
+function EmptyState({ t, mode }: { t: TFunction; mode: QuizMode }) {
+  const isStruggling = mode === 'struggling';
   return (
     <View style={styles.centeredContainer}>
       <View style={[styles.emptyCard, shadowStyle]}>
         <Text style={styles.emptyTitle}>
-          {t('quiz_mode.all_caught_up').toUpperCase()}
+          {isStruggling
+            ? t('quiz_mode.no_struggling_words').toUpperCase()
+            : t('quiz_mode.all_caught_up').toUpperCase()}
         </Text>
         <Text style={styles.emptySubtext}>
-          {t('quiz_mode.no_cards_due_for_review')}
+          {isStruggling
+            ? t('quiz_mode.no_struggling_words_desc')
+            : t('quiz_mode.no_cards_due_for_review')}
         </Text>
       </View>
       <Pressable
@@ -124,7 +134,7 @@ function PlayingState({
   eszettPreference,
 }: PlayingStateProps) {
   const { t } = useTranslation('app');
-  const { currentCard, phase, selectedArticle, isCorrect, progress } = quiz;
+  const { currentCard, phase, selectedArticle, isCorrect, progress, mode } = quiz;
   const translation = useNounTranslation(
     currentCard?.remote_id ?? null,
     currentCard?.english ?? null,
@@ -152,16 +162,25 @@ function PlayingState({
 
   return (
     <View style={styles.playingContainer}>
-      {/* ── Close button ────────────────────────────────────── */}
-      <Pressable
-        style={styles.closeButton}
-        onPress={() => router.back()}
-        accessibilityRole="button"
-        accessibilityLabel={t('quiz_mode.exit_quiz')}
-        hitSlop={12}
-      >
-        <Text style={styles.closeButtonText}>X</Text>
-      </Pressable>
+      {/* ── Top row: close + mode badge ─────────────────────── */}
+      <View style={styles.topRow}>
+        {mode === 'struggling' && (
+          <View style={styles.modeBadge}>
+            <Text style={styles.modeBadgeText}>
+              {t('quiz_mode.hard_words_drill').toUpperCase()}
+            </Text>
+          </View>
+        )}
+        <Pressable
+          style={styles.closeButton}
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel={t('quiz_mode.exit_quiz')}
+          hitSlop={12}
+        >
+          <Text style={styles.closeButtonText}>X</Text>
+        </Pressable>
+      </View>
 
       {/* ── Progress ────────────────────────────────────────── */}
       <View style={styles.progressSection}>
@@ -422,9 +441,28 @@ const styles = StyleSheet.create({
     padding: Layout.screenPadding,
   },
 
+  // Top row (close + mode badge)
+  topRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  modeBadge: {
+    backgroundColor: AppColors.red,
+    borderWidth: Layout.borderWidthThin,
+    borderColor: AppColors.black,
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.sm,
+  },
+  modeBadgeText: {
+    fontSize: Typography.tiny,
+    fontWeight: Typography.bold,
+    color: AppColors.white,
+    letterSpacing: 1,
+  },
+
   // Close button
   closeButton: {
-    alignSelf: 'flex-end',
     width: 44,
     height: 44,
     borderWidth: Layout.borderWidthThin,

--- a/hooks/use-home-data.ts
+++ b/hooks/use-home-data.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 import { vocabularyService } from '@/services/vocabularyService';
 import { spacedRepetitionService } from '@/services/spacedRepetitionService';
+import { statisticsService } from '@/services/statisticsService';
 import type { UserStats } from '@/types/database';
 
 interface HomeData {
@@ -10,6 +11,7 @@ interface HomeData {
   userNounCount: number;
   streak: number;
   hasReviewedToday: boolean;
+  strugglingCount: number;
   isLoading: boolean;
 }
 
@@ -32,6 +34,7 @@ export function useHomeData(): HomeData {
   const [userNounCount, setUserNounCount] = useState(0);
   const [streak, setStreak] = useState(0);
   const [hasReviewedToday, setHasReviewedToday] = useState(false);
+  const [strugglingCount, setStrugglingCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
 
   useFocusEffect(
@@ -46,12 +49,14 @@ export function useHomeData(): HomeData {
             fetchedUserCount,
             fetchedStreak,
             fetchedHasReviewedToday,
+            fetchedStrugglingCount,
           ] = await Promise.all([
             vocabularyService.getUserStats(),
             vocabularyService.getNounCount(),
             vocabularyService.getUserNounCount(),
             spacedRepetitionService.getStudyStreak(),
             spacedRepetitionService.hasReviewedToday(),
+            statisticsService.getStrugglingWordsCount(),
           ]);
 
           if (!cancelled) {
@@ -60,6 +65,7 @@ export function useHomeData(): HomeData {
             setUserNounCount(fetchedUserCount);
             setStreak(fetchedStreak);
             setHasReviewedToday(fetchedHasReviewedToday);
+            setStrugglingCount(fetchedStrugglingCount);
           }
         } catch (error) {
           console.error('[HomeData] Failed to load:', error);
@@ -78,5 +84,5 @@ export function useHomeData(): HomeData {
     }, []),
   );
 
-  return { stats, nounCount, userNounCount, streak, hasReviewedToday, isLoading };
+  return { stats, nounCount, userNounCount, streak, hasReviewedToday, strugglingCount, isLoading };
 }

--- a/hooks/use-quiz-session.ts
+++ b/hooks/use-quiz-session.ts
@@ -21,6 +21,7 @@ export interface QuizResult {
 }
 
 export interface QuizSessionData {
+  mode: QuizMode;
   phase: QuizPhase;
   currentCard: DueCard | null;
   selectedArticle: Article | null;
@@ -33,11 +34,16 @@ export interface QuizSessionData {
 
 // ── Hook ─────────────────────────────────────────────────────────────
 
+export type QuizMode = 'daily' | 'struggling';
+
 /**
  * Manages the full quiz lifecycle: loading a session, presenting cards,
  * recording answers with SM-2 scoring, and tracking results.
+ *
+ * @param mode - 'daily' uses the normal SRS schedule; 'struggling' drills
+ *               the words the user misses most (ignores next_review_date).
  */
-export function useQuizSession(): QuizSessionData {
+export function useQuizSession(mode: QuizMode = 'daily'): QuizSessionData {
   const [phase, setPhase] = useState<QuizPhase>('loading');
   const [session, setSession] = useState<ReviewSession | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -54,15 +60,20 @@ export function useQuizSession(): QuizSessionData {
 
     async function loadSession() {
       try {
-        // Load selected categories from settings
-        const categoryIds = await settingsService.getSelectedCategories();
+        let reviewSession;
 
-        const reviewSession =
-          await spacedRepetitionService.getDailyReviewSession(
+        if (mode === 'struggling') {
+          reviewSession =
+            await spacedRepetitionService.getStrugglingWordsSession(15);
+        } else {
+          // Load selected categories from settings
+          const categoryIds = await settingsService.getSelectedCategories();
+          reviewSession = await spacedRepetitionService.getDailyReviewSession(
             20,
             5,
             categoryIds.length > 0 ? categoryIds : undefined,
           );
+        }
 
         if (cancelled) return;
 
@@ -162,6 +173,7 @@ export function useQuizSession(): QuizSessionData {
   // ── Return ───────────────────────────────────────────────────────
 
   return {
+    mode,
     phase,
     currentCard,
     selectedArticle,

--- a/locales/en.json
+++ b/locales/en.json
@@ -25,6 +25,9 @@
     "accuracy": "accuracy",
     "quiz": "Quiz",
     "back_to_home": "Back to home",
+    "struggling_words_button_one": "DRILL {{count}} HARD WORD",
+    "struggling_words_button_other": "DRILL {{count}} HARD WORDS",
+    "struggling_words_label": "words you keep missing",
     "words_count_one": "{{count}} word",
     "words_count_other": "{{count}} words",
     "quiz_mode": {
@@ -37,7 +40,10 @@
       "reviewed": "Reviewed",
       "correct": "Correct",
       "accuracy": "Accuracy",
-      "you_said": "You said: {{article}}"
+      "you_said": "You said: {{article}}",
+      "hard_words_drill": "Hard Words Drill",
+      "no_struggling_words": "Looking good!",
+      "no_struggling_words_desc": "You have no words below 60% accuracy yet.\n\nKeep practicing and your toughest words will appear here."
     },
     "settings": {
       "title": "Settings",

--- a/locales/it.json
+++ b/locales/it.json
@@ -25,6 +25,9 @@
     "accuracy": "precisione",
     "quiz": "Quiz",
     "back_to_home": "Torna alla home",
+    "struggling_words_button_one": "RIPASSA {{count}} PAROLA DIFFICILE",
+    "struggling_words_button_other": "RIPASSA {{count}} PAROLE DIFFICILI",
+    "struggling_words_label": "parole che continui a sbagliare",
     "words_count_one": "{{count}} parola",
     "words_count_other": "{{count}} parole",
     "quiz_mode": {
@@ -37,7 +40,10 @@
       "reviewed": "Ripetute",
       "correct": "Corrette",
       "accuracy": "Precisione",
-      "you_said": "Hai detto: {{article}}"
+      "you_said": "Hai detto: {{article}}",
+      "hard_words_drill": "Ripasso parole difficili",
+      "no_struggling_words": "Ottimo lavoro!",
+      "no_struggling_words_desc": "Non hai ancora parole con precisione inferiore al 60%.\n\nContinua a praticare e le parole più difficili appariranno qui."
     },
     "settings": {
       "title": "Impostazioni",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -29,6 +29,11 @@
     "accuracy": "dokładność",
     "quiz": "Quiz",
     "back_to_home": "Wróć do strony głównej",
+    "struggling_words_button_one": "ĆWICZ {{count}} TRUDNE SŁOWO",
+    "struggling_words_button_few": "ĆWICZ {{count}} TRUDNE SŁOWA",
+    "struggling_words_button_many": "ĆWICZ {{count}} TRUDNYCH SŁÓW",
+    "struggling_words_button_other": "ĆWICZ {{count}} TRUDNYCH SŁÓW",
+    "struggling_words_label": "słowa, które ciągle mylisz",
     "words_count_one": "{{count}} słowo",
     "words_count_few": "{{count}} słowa",
     "words_count_many": "{{count}} słów",
@@ -43,7 +48,10 @@
       "reviewed": "Powtórzone",
       "correct": "Poprawne",
       "accuracy": "Dokładność",
-      "you_said": "Twoja odpowiedź: {{article}}"
+      "you_said": "Twoja odpowiedź: {{article}}",
+      "hard_words_drill": "Trudne słowa",
+      "no_struggling_words": "Świetnie!",
+      "no_struggling_words_desc": "Nie masz jeszcze słów poniżej 60% trafności.\n\nĆwicz dalej, a najtrudniejsze słowa pojawią się tutaj."
     },
     "settings": {
       "title": "Ustawienia",

--- a/services/spacedRepetitionService.ts
+++ b/services/spacedRepetitionService.ts
@@ -259,6 +259,31 @@ export class SpacedRepetitionService {
   }
 
   /**
+   * Build a focused session of the words the user struggles with most.
+   * Selects cards with ≥5 reviews and a success rate below 60%, sorted worst-first.
+   * Ignores next_review_date so struggling words are always drillable on demand.
+   */
+  async getStrugglingWordsSession(limit: number = 15): Promise<ReviewSession> {
+    const cards = await this.db.getAllAsync<DueCard>(
+      `SELECT cp.*, n.german AS word, n.article, n.english, n.translation_key, n.remote_id
+       FROM card_progress cp
+       JOIN nouns n ON cp.word_type = 'noun' AND cp.word_id = n.id
+       WHERE cp.total_reviews >= 5
+         AND CAST(cp.correct_reviews AS REAL) / cp.total_reviews < 0.6
+       ORDER BY CAST(cp.correct_reviews AS REAL) / cp.total_reviews ASC,
+                cp.total_reviews DESC
+       LIMIT ?`,
+      [limit],
+    );
+
+    return {
+      cards: shuffleArray(cards),
+      dueCount: cards.length,
+      newCount: 0,
+    };
+  }
+
+  /**
    * Check if the user has completed at least one review today.
    */
   async hasReviewedToday(): Promise<boolean> {

--- a/services/statisticsService.ts
+++ b/services/statisticsService.ts
@@ -74,6 +74,22 @@ export class StatisticsService {
   }
 
   /**
+   * Count words the user consistently struggles with.
+   * A word is "struggling" when it has enough reviews (minReviews) but a success
+   * rate below 60% — meaning the user keeps getting it wrong.
+   */
+  async getStrugglingWordsCount(minReviews: number = 5): Promise<number> {
+    const result = await this.db.getFirstAsync<{ count: number }>(
+      `SELECT COUNT(*) AS count
+       FROM card_progress
+       WHERE total_reviews >= ?
+         AND CAST(correct_reviews AS REAL) / total_reviews < 0.6`,
+      [minReviews],
+    );
+    return result?.count ?? 0;
+  }
+
+  /**
    * Count words considered "mastered" — interval of at least 21 days means
    * the card is solidly in long-term memory.
    */


### PR DESCRIPTION
Users who keep missing the same articles now have a dedicated practice
mode that drills their worst words on demand, without waiting for the
SRS schedule.

Changes:
- spacedRepetitionService: add getStrugglingWordsSession() — fetches
  cards with ≥5 reviews and <60% success rate, worst-first
- statisticsService: add getStrugglingWordsCount() for home screen badge
- useQuizSession: accept mode param ('daily' | 'struggling')
- use-home-data: expose strugglingCount to home screen
- quiz.tsx: read ?mode=struggling from URL, show red "HARD WORDS DRILL"
  badge in the header, custom empty-state message when no hard words
- Home screen: show a red "DRILL N HARD WORDS" CTA when strugglingCount>0,
  linking directly to /quiz?mode=struggling
- All three locales (en/pl/it) updated with new translation keys

https://claude.ai/code/session_0198vabMvu3cHNKE4kcJ2jHL