### PR TITLE
docs: add v1.4.0 release notes for hard-words drill mode

### DIFF
--- a/release-notes/v1.4.0.md
+++ b/release-notes/v1.4.0.md
@@ -1,0 +1,69 @@
+# Release Notes — v1.4.0
+
+**Release date:** 2026-02-26
+**Branch:** staging → main
+
+---
+
+## What's New
+
+### Hard Words Drill Mode
+
+The biggest addition in this release is a dedicated drill mode for words you consistently struggle with.
+
+**How it works:**
+- After accumulating at least 5 reviews on a word, Üben tracks your accuracy. Any word you're getting right less than 60% of the time is flagged as a "struggling" word.
+- A new button appears on the home screen (styled in red) showing exactly how many struggling words you have, e.g. *"DRILL 7 HARD WORDS"*.
+- Tapping it launches a focused quiz session (up to 15 cards) sorted worst-first — your most-missed words come first.
+- The quiz screen shows a **"Hard Words Drill"** badge at the top so you always know which mode you're in.
+- If you have no struggling words yet, the empty state gives positive feedback and explains when words will appear there.
+
+This mode is available on demand at any time — it ignores the normal spaced-repetition schedule so you can drill hard words whenever you want.
+
+---
+
+## Changes by Area
+
+### New Features
+- **Home screen** — "Drill Hard Words" button appears dynamically when struggling words exist; hidden when you have none.
+- **Quiz session** — New `struggling` mode loads words by accuracy rate rather than due date; shuffled so the order varies each session.
+- **SpacedRepetitionService** — New `getStrugglingWordsSession(limit)` method queries for cards with ≥5 reviews and <60% success rate, ordered worst-first.
+- **StatisticsService** — New `getStrugglingWordsCount(minReviews)` method for the home screen count badge.
+- **Quiz URL routing** — The quiz screen now accepts a `?mode=struggling` query parameter, making the mode deep-linkable.
+- **Empty state** — Quiz empty state is mode-aware: shows "Looking good!" with an explanation for struggling mode vs. the standard "All caught up" for daily mode.
+
+### Localisation
+Struggling words UI strings added in all three supported languages:
+
+| Key | EN | IT | PL |
+|---|---|---|---|
+| Button (singular) | DRILL 1 HARD WORD | RIPASSA 1 PAROLA DIFFICILE | ĆWICZ 1 TRUDNE SŁOWO |
+| Button (plural) | DRILL N HARD WORDS | RIPASSA N PAROLE DIFFICILI | ĆWICZ N TRUDNYCH SŁÓW |
+| Subtitle | words you keep missing | parole che continui a sbagliare | słowa, które ciągle mylisz |
+| Mode badge | Hard Words Drill | Ripasso parole difficili | Trudne słowa |
+| Empty title | Looking good! | Ottimo lavoro! | Świetnie! |
+| Empty description | You have no words below 60% accuracy yet… | Non hai ancora parole… | Nie masz jeszcze słów… |
+
+Polish also adds the correct grammatical plural forms (`_few`, `_many`, `_other`) per Polish pluralisation rules.
+
+### Internal / Housekeeping
+- `useHomeData` hook extended to fetch and expose `strugglingCount` alongside existing home screen data.
+- `useQuizSession` hook now accepts a `QuizMode` parameter (`'daily' | 'struggling'`); exported as a named type for use across the app.
+- `QuizSessionData` interface updated to expose the active `mode` so child components (e.g. the mode badge) can read it without prop drilling.
+
+---
+
+## Version Bump
+
+`1.3.0` → `1.4.0` across `app.config.js`, `package.json`, and `package-lock.json`.
+
+---
+
+## How to Test
+
+1. Practice a noun incorrectly at least 5 times (or seed a card with low accuracy in the DB).
+2. Return to the home screen — the red "DRILL N HARD WORDS" button should appear.
+3. Tap it and confirm the Hard Words Drill badge is visible in the quiz.
+4. Finish or exit the session and confirm you're returned to the home screen.
+5. On a fresh account with no struggling words, confirm the button is hidden.
+6. Navigate directly to `/quiz?mode=struggling` to verify deep-link routing works.


### PR DESCRIPTION
Summarises the staging → main diff: new struggling-words drill mode, home screen button, quiz mode routing, stats service changes, and localisation additions across EN/IT/PL.

https://claude.ai/code/session_01M5og4HuXotvuawVvrfqoHv