### PR TITLE
Remove ad monetization and promo code functionality

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -41,13 +41,6 @@ export default {
     plugins: [
       'expo-router',
       [
-        'react-native-google-mobile-ads',
-        {
-          androidAppId: 'ca-app-pub-3399938065938082/4693073685',
-          iosAppId: 'ca-app-pub-3399938065938082~7320604001',
-        },
-      ],
-      [
         'expo-splash-screen',
         {
           image: './assets/images/splash-icon.png',

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -16,7 +16,6 @@ import {
   StyleSheet,
   Switch,
   Text,
-  TextInput,
   View,
 } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
@@ -35,27 +34,8 @@ export default function SettingsScreen() {
     setEszettPreference,
     appLanguage,
     setAppLanguage,
-    adsDisabled,
-    redeemPromoCode,
     isLoading,
   } = useSettings();
-
-  const [promoCode, setPromoCode] = useState('');
-  const [promoStatus, setPromoStatus] = useState<'idle' | 'loading' | 'invalid'>('idle');
-
-  const handleRedeemCode = async () => {
-    const trimmed = promoCode.trim();
-    if (!trimmed) return;
-    setPromoStatus('loading');
-    const result = await redeemPromoCode(trimmed);
-    if (result === 'success') {
-      setPromoCode('');
-      setPromoStatus('idle');
-    } else {
-      setPromoStatus('invalid');
-      setTimeout(() => setPromoStatus('idle'), 2000);
-    }
-  };
 
   const [diagnostics, setDiagnostics] = useState<MigrationDiagnostics | null>(
     null,
@@ -289,64 +269,6 @@ export default function SettingsScreen() {
             </View>
           </View>
         </View>
-        {/* ── Promo Code Card ─────────────────────────────────────── */}
-        <View style={[styles.card, shadowStyle]}>
-          <Text style={styles.cardTitle}>PROMO CODE</Text>
-
-          {adsDisabled ? (
-            <View style={styles.settingRow}>
-              <View style={styles.settingTextGroup}>
-                <Text style={styles.settingLabel}>AD-FREE</Text>
-                <Text style={styles.settingDescription}>
-                  Ads have been disabled with a promo code.
-                </Text>
-              </View>
-              <View style={styles.promoSuccessBadge}>
-                <Text style={styles.promoSuccessBadgeText}>ACTIVE</Text>
-              </View>
-            </View>
-          ) : (
-            <View style={styles.settingRowStacked}>
-              <Text style={styles.settingDescription}>
-                Have a promo code? Enter it below to disable ads.
-              </Text>
-              <View style={styles.promoInputRow}>
-                <TextInput
-                  style={[
-                    styles.promoInput,
-                    promoStatus === 'invalid' && styles.promoInputInvalid,
-                  ]}
-                  value={promoCode}
-                  onChangeText={setPromoCode}
-                  placeholder="ENTER CODE"
-                  placeholderTextColor={AppColors.textSecondary}
-                  autoCapitalize="characters"
-                  autoCorrect={false}
-                  returnKeyType="done"
-                  onSubmitEditing={handleRedeemCode}
-                  editable={promoStatus !== 'loading'}
-                />
-                <Pressable
-                  style={({ pressed }) => [
-                    styles.promoButton,
-                    promoStatus === 'loading' && styles.promoButtonDisabled,
-                    pressed && styles.segmentButtonPressed,
-                  ]}
-                  onPress={handleRedeemCode}
-                  disabled={promoStatus === 'loading' || !promoCode.trim()}
-                >
-                  <Text style={styles.promoButtonText}>
-                    {promoStatus === 'loading' ? '...' : 'REDEEM'}
-                  </Text>
-                </Pressable>
-              </View>
-              {promoStatus === 'invalid' && (
-                <Text style={styles.promoError}>Invalid promo code.</Text>
-              )}
-            </View>
-          )}
-        </View>
-
         {/* ── Database Diagnostics Card (unlocked by tapping header 7×) ── */}
         {showDiagnostics && (
           <View style={[styles.card, shadowStyle]}>
@@ -575,63 +497,6 @@ const styles = StyleSheet.create({
   },
   segmentButtonTextActive: {
     color: AppColors.white,
-  },
-
-  // Promo code
-  promoInputRow: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginTop: Spacing.md,
-  },
-  promoInput: {
-    flex: 1,
-    borderWidth: Layout.borderWidth,
-    borderColor: AppColors.black,
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.sm,
-    fontSize: Typography.body,
-    fontWeight: Typography.bold,
-    color: AppColors.black,
-    letterSpacing: 1,
-  },
-  promoInputInvalid: {
-    borderColor: AppColors.red,
-  },
-  promoButton: {
-    backgroundColor: AppColors.yellow,
-    borderWidth: Layout.borderWidth,
-    borderColor: AppColors.black,
-    paddingHorizontal: Spacing.md,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  promoButtonDisabled: {
-    opacity: 0.5,
-  },
-  promoButtonText: {
-    fontSize: Typography.small,
-    fontWeight: Typography.bold,
-    color: AppColors.black,
-    letterSpacing: 0.5,
-  },
-  promoError: {
-    marginTop: Spacing.sm,
-    fontSize: Typography.small,
-    fontWeight: Typography.semibold,
-    color: AppColors.red,
-  },
-  promoSuccessBadge: {
-    backgroundColor: AppColors.green,
-    borderWidth: Layout.borderWidthThin,
-    borderColor: AppColors.black,
-    paddingVertical: 2,
-    paddingHorizontal: Spacing.sm,
-  },
-  promoSuccessBadgeText: {
-    fontSize: Typography.tiny,
-    fontWeight: Typography.bold,
-    color: AppColors.white,
-    letterSpacing: 1,
   },
 
   // Easter-egg tap progress

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,8 +2,6 @@ import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
-import { Platform } from 'react-native';
-import mobileAds from 'react-native-google-mobile-ads';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import 'react-native-reanimated';
 
@@ -21,12 +19,6 @@ export default function RootLayout() {
   const { isReady, error } = useDatabase();
   const [showingSplash, setShowingSplash] = useState(true);
   const [splashAnimationDone, setSplashAnimationDone] = useState(false);
-
-  useEffect(() => {
-    if (Platform.OS !== 'web') {
-      mobileAds().initialize().catch(console.error);
-    }
-  }, []);
 
   // When splash animation finishes AND database is ready, hide splash
   useEffect(() => {

--- a/app/quiz.tsx
+++ b/app/quiz.tsx
@@ -19,18 +19,16 @@ import { getNounFontSize } from '@/utils/typography';
 import * as Haptics from 'expo-haptics';
 import { router, useLocalSearchParams } from 'expo-router';
 import { TFunction } from 'i18next';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
-import { TestIds, useInterstitialAd } from 'react-native-google-mobile-ads';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 // ── Constants ────────────────────────────────────────────────────────
@@ -38,15 +36,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 const ARTICLES = ['der', 'die', 'das'] as const;
 type Article = (typeof ARTICLES)[number];
 const FEEDBACK_DELAY_MS = 1200;
-
-const INTERSTITIAL_AD_UNIT_ID = __DEV__
-  ? TestIds.INTERSTITIAL
-  : 'ca-app-pub-3399938065938082/1137175310';
-
-// Show an interstitial ad every N answered cards
-const AD_FREQUENCY = 10;
-
-const IS_NATIVE = Platform.OS !== 'web';
 
 // Maps each article to its learning color:
 // der (masculine) → blue, die (feminine) → pink, das (neuter) → green
@@ -72,67 +61,14 @@ export default function QuizScreen() {
   const {
     showEnglishHint,
     eszettPreference,
-    adsDisabled,
-    isLoading: settingsLoading,
   } = useSettings();
-
-  // ── Interstitial ad ──────────────────────────────────────────────
-  const { isLoaded, isClosed, load, show } = useInterstitialAd(
-    INTERSTITIAL_AD_UNIT_ID,
-  );
-  // Count of cards answered since the last ad was shown
-  const cardCountRef = useRef(0);
-  // Guards the isClosed effect so it only fires after we explicitly showed an ad
-  const adIsShowingRef = useRef(false);
-
-  // Preload the first ad once settings have loaded and ads are not disabled
-  useEffect(() => {
-    if (!settingsLoading && IS_NATIVE && !adsDisabled) load();
-  }, [settingsLoading]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // When the ad closes, advance to the next card and preload the next ad.
-  // The card timer (cardStartTime in the hook) is set inside nextCard(), so it
-  // only starts after the ad is dismissed — the ad never counts against the user's time.
-  useEffect(() => {
-    if (!isClosed || !adIsShowingRef.current) return;
-    adIsShowingRef.current = false;
-    nextCard();
-    if (IS_NATIVE && !adsDisabled) load();
-  }, [isClosed, nextCard, load, adsDisabled]);
-
-  // Called after the feedback delay. Shows an interstitial every AD_FREQUENCY
-  // cards (skipped on the last card so we don't delay the results screen).
-  const nextCardOrShowAd = useCallback(() => {
-    const isLastCard = progress.current === progress.total;
-
-    if (!isLastCard) cardCountRef.current += 1;
-
-    if (
-      !isLastCard &&
-      IS_NATIVE &&
-      !adsDisabled &&
-      isLoaded &&
-      cardCountRef.current >= AD_FREQUENCY
-    ) {
-      cardCountRef.current = 0;
-      adIsShowingRef.current = true;
-      show();
-    } else {
-      nextCard();
-    }
-  }, [isLoaded, show, nextCard, progress, adsDisabled]);
 
   // Auto-advance after feedback
   useEffect(() => {
     if (phase !== 'feedback') return;
-    // Don't restart the timer if an ad is already on screen — the isClosed
-    // effect will call nextCard() once the user dismisses the ad.
-    if (adIsShowingRef.current) return;
-
-    const timer = setTimeout(nextCardOrShowAd, FEEDBACK_DELAY_MS);
-
+    const timer = setTimeout(nextCard, FEEDBACK_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [phase, nextCardOrShowAd]);
+  }, [phase, nextCard]);
 
   return (
     <SafeAreaView style={styles.safeArea}>

--- a/hooks/use-settings.ts
+++ b/hooks/use-settings.ts
@@ -2,13 +2,6 @@ import i18n from '@/constants/i18n';
 import { settingsService } from '@/services/settingsService';
 import { useCallback, useEffect, useState } from 'react';
 
-// Promo codes that disable ads, stored as a comma-separated env var.
-// e.g. EXPO_PUBLIC_PROMO_CODES=UBEN2024,PARTNER01
-const PROMO_CODES: string[] = (process.env.EXPO_PUBLIC_PROMO_CODES ?? '')
-  .split(',')
-  .map((c: string) => c.trim().toUpperCase())
-  .filter(Boolean);
-
 /**
  * Hook to read and toggle the "Show English Hint" setting.
  *
@@ -21,7 +14,6 @@ export function useSettings() {
     'eszett' | 'ss'
   >('eszett');
   const [appLanguage, setAppLanguageState] = useState<'en' | 'it' | 'pl'>('en');
-  const [adsDisabled, setAdsDisabledState] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   // ── Load on mount ──────────────────────────────────────────────────
@@ -31,17 +23,15 @@ export function useSettings() {
 
     (async () => {
       try {
-        const [englishHint, eszett, language, adsOff] = await Promise.all([
+        const [englishHint, eszett, language] = await Promise.all([
           settingsService.getShowEnglishHint(),
           settingsService.getEszettPreference(),
           settingsService.getAppLanguage(),
-          settingsService.getAdsDisabled(),
         ]);
         if (!cancelled) {
           setShowEnglishHintState(englishHint);
           setEszettPreferenceState(eszett);
           setAppLanguageState(language);
-          setAdsDisabledState(adsOff);
         }
       } catch (error) {
         console.error('[Settings] Failed to load settings:', error);
@@ -100,25 +90,6 @@ export function useSettings() {
     [appLanguage],
   );
 
-  /** Attempt to redeem a promo code. Returns 'success' or 'invalid'. */
-  const redeemPromoCode = useCallback(
-    async (code: string): Promise<'success' | 'invalid'> => {
-      if (PROMO_CODES.includes(code.trim().toUpperCase())) {
-        setAdsDisabledState(true);
-        try {
-          await settingsService.setAdsDisabled(true);
-        } catch (error) {
-          console.error('[Settings] Failed to save ads_disabled:', error);
-          setAdsDisabledState(false);
-          return 'invalid';
-        }
-        return 'success';
-      }
-      return 'invalid';
-    },
-    [],
-  );
-
   return {
     showEnglishHint,
     setShowEnglishHint,
@@ -126,8 +97,6 @@ export function useSettings() {
     setEszettPreference,
     appLanguage,
     setAppLanguage,
-    adsDisabled,
-    redeemPromoCode,
     isLoading,
   };
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "react-i18next": "^16.5.4",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-google-mobile-ads": "^16.0.3",
     "react-native-keyboard-controller": "1.18.5",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/services/settingsService.ts
+++ b/services/settingsService.ts
@@ -10,7 +10,6 @@ export const SETTINGS_KEYS = {
   APP_LANGUAGE: 'app_language',
   QUIZ_SESSIONS_COMPLETED: 'quiz_sessions_completed',
   LAST_REVIEW_REQUEST_DATE: 'last_review_request_date',
-  ADS_DISABLED: 'ads_disabled',
 } as const;
 
 // ── Settings Service ──────────────────────────────────────────────────
@@ -100,20 +99,6 @@ class SettingsService {
     await this.setSetting(SETTINGS_KEYS.APP_LANGUAGE, language);
   }
 
-  // ── Convenience: Ads Disabled ──────────────────────────────────────
-
-  /** Whether ads have been disabled via a promo code. Default: false. */
-  async getAdsDisabled(): Promise<boolean> {
-    const value = await this.getSetting(SETTINGS_KEYS.ADS_DISABLED);
-    return value === 'true';
-  }
-
-  async setAdsDisabled(disabled: boolean): Promise<void> {
-    await this.setSetting(
-      SETTINGS_KEYS.ADS_DISABLED,
-      disabled ? 'true' : 'false',
-    );
-  }
 }
 
 export const settingsService = new SettingsService();


### PR DESCRIPTION
## Summary
This PR removes all ad-related functionality from the application, including Google Mobile Ads integration, interstitial ad display logic, and the promo code redemption system.

## Key Changes

- **Removed ad infrastructure**: Deleted Google Mobile Ads initialization from root layout and removed the plugin configuration from `app.config.js`
- **Removed promo code system**: Eliminated the promo code input UI, validation logic, and related settings from the settings screen
- **Simplified quiz screen**: Removed interstitial ad display logic, ad frequency tracking, and ad-related state management from the quiz flow
- **Cleaned up settings hook**: Removed `adsDisabled` state, `redeemPromoCode` callback, and promo code validation logic
- **Removed settings persistence**: Deleted `ADS_DISABLED` setting key and related getter/setter methods from `settingsService`
- **Simplified auto-advance logic**: Removed ad-aware card advancement in quiz, now directly calls `nextCard()` after feedback delay instead of conditionally showing ads

## Implementation Details

- The quiz screen's auto-advance timer now directly transitions to the next card without checking for ad display conditions
- Removed all references to `adsDisabled` from component props and state management
- Cleaned up unused imports (`TextInput`, `useCallback`, `Platform`, `TestIds`, `useInterstitialAd`)
- Removed promo code styling constants from the settings screen stylesheet

https://claude.ai/code/session_01Um8W7h3pNuRPuA5iE4javd