### PR TITLE
Add app version display to settings screen

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -8,6 +8,7 @@ import {
 import { getMigrationDiagnostics } from '@/database/db';
 import { useSettings } from '@/hooks/use-settings';
 import type { MigrationDiagnostics } from '@/types/database';
+import Constants from 'expo-constants';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -353,6 +354,11 @@ export default function SettingsScreen() {
             )}
           </View>
         )}
+
+        {/* ── Version ─────────────────────────────────────────── */}
+        <Text style={styles.versionText}>
+          v{Constants.expoConfig?.version ?? '—'}
+        </Text>
       </KeyboardAwareScrollView>
     </SafeAreaView>
   );
@@ -608,5 +614,13 @@ const styles = StyleSheet.create({
     fontWeight: Typography.regular,
     color: AppColors.textSecondary,
     flex: 1,
+  },
+  versionText: {
+    fontSize: Typography.tiny,
+    fontWeight: Typography.semibold,
+    color: AppColors.textSecondary,
+    textAlign: 'center',
+    letterSpacing: 1,
+    marginTop: Spacing.sm,
   },
 });


### PR DESCRIPTION
## Summary

Adds the app version number to the bottom of the settings screen, sourced from the Expo config. This provides users with a quick way to check their installed app version.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code quality
- [ ] Database / migration change
- [ ] Dependency update
- [ ] Docs / config only

## Related Issue

Closes #61 

## Changes

- Import `Constants` from `expo-constants` to access app version metadata
- Add version display text at the bottom of the settings screen showing `v{version}` or `v—` if unavailable
- Add `versionText` style with appropriate typography, color, alignment, and spacing to match the app's design system

## Testing

- [x] Tested on iOS
- [x] Tested on Android
- No edge cases or database operations involved

## Checklist

- [x] `npm run lint` passes
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] No inline styles — all styles use `StyleSheet.create()`
- [x] No `console.log` left in production paths

https://claude.ai/code/session_017y3tnaT172aHE9w9k2Gtcd