### PR TITLE
Add AdMob integration with banner and interstitial ads

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -332,7 +332,7 @@ eas submit --platform ios
 
 ### AdMob Integration
 
-- Banner ads on non-critical screens (settings, word list) — `components/ads/ad-banner.tsx`
+- Banner ads on non-critical screens (progress, word list) — `components/ads/ad-banner.tsx`
 - Interstitial ads between quiz sessions, every 3rd completed session (not mid-quiz) — `hooks/use-quiz-interstitial-ad.ts`
 - Rewarded ads for unlocking features (future)
 - Never interrupt active learning

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -332,10 +332,13 @@ eas submit --platform ios
 
 ### AdMob Integration
 
-- Banner ads on non-critical screens (settings, word list)
-- Interstitial ads between quiz sessions (not mid-quiz)
+- Banner ads on non-critical screens (settings, word list) — `components/ads/ad-banner.tsx`
+- Interstitial ads between quiz sessions, every 3rd completed session (not mid-quiz) — `hooks/use-quiz-interstitial-ad.ts`
 - Rewarded ads for unlocking features (future)
 - Never interrupt active learning
+- Ships with Google's test ad unit IDs by default (`constants/ads.ts`) so builds work before a real AdMob account exists; override with `EXPO_PUBLIC_ADMOB_BANNER_UNIT_ID`, `EXPO_PUBLIC_ADMOB_INTERSTITIAL_UNIT_ID`, `EXPO_PUBLIC_ADMOB_ANDROID_APP_ID`, `EXPO_PUBLIC_ADMOB_IOS_APP_ID`
+- AdMob is not supported on web — ad components/hooks have `.web` stub variants that render/do nothing there
+- IAP (ad-free unlock, premium features) is intentionally deferred to a later phase
 
 ## Future Roadmap
 

--- a/app.config.js
+++ b/app.config.js
@@ -19,7 +19,7 @@ export default {
   expo: {
     name: `üben${getAppVariant()}`,
     slug: 'uben',
-    version: '1.7.0',
+    version: '1.8.0',
     orientation: 'portrait',
     icon: `./assets/images/icon${IS_PREVIEW ? '-preview' : ''}.png`,
     scheme: 'germanpractice',

--- a/app.config.js
+++ b/app.config.js
@@ -68,6 +68,19 @@ export default {
           },
         },
       ],
+      [
+        'react-native-google-mobile-ads',
+        {
+          // Google's sample App IDs, used until real AdMob app IDs are issued.
+          // Safe to ship with test IDs — no real ads or revenue will be served.
+          androidAppId:
+            process.env.EXPO_PUBLIC_ADMOB_ANDROID_APP_ID ||
+            'ca-app-pub-3940256099942544~3347511713',
+          iosAppId:
+            process.env.EXPO_PUBLIC_ADMOB_IOS_APP_ID ||
+            'ca-app-pub-3940256099942544~1458002511',
+        },
+      ],
     ],
     experiments: {
       typedRoutes: true,

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,3 +1,4 @@
+import { AdBanner } from '@/components/ads/ad-banner';
 import {
   AppColors,
   Layout,
@@ -405,6 +406,13 @@ export default function ProgressScreen() {
             </Text>
           </View>
         )}
+
+        {/* ── Ad Banner ─────────────────────────────────────────── */}
+        {!isLoading && hasAnyData && (
+          <View style={styles.adContainer}>
+            <AdBanner />
+          </View>
+        )}
       </ScrollView>
     </SafeAreaView>
   );
@@ -656,5 +664,10 @@ const styles = StyleSheet.create({
     color: AppColors.textSecondary,
     lineHeight: 24,
     textAlign: 'center',
+  },
+
+  // ── Ad banner
+  adContainer: {
+    marginTop: Spacing.sm,
   },
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,4 +1,3 @@
-import { AdBanner } from '@/components/ads/ad-banner';
 import {
   AppColors,
   Layout,
@@ -356,11 +355,6 @@ export default function SettingsScreen() {
           </View>
         )}
 
-        {/* ── Ad Banner ───────────────────────────────────────── */}
-        <View style={styles.adContainer}>
-          <AdBanner />
-        </View>
-
         {/* ── Version ─────────────────────────────────────────── */}
         <Text style={styles.versionText}>
           v{Constants.expoConfig?.version ?? '—'}
@@ -628,8 +622,5 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     letterSpacing: 1,
     marginTop: Spacing.sm,
-  },
-  adContainer: {
-    marginTop: Spacing.lg,
   },
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,3 +1,4 @@
+import { AdBanner } from '@/components/ads/ad-banner';
 import {
   AppColors,
   Layout,
@@ -355,6 +356,11 @@ export default function SettingsScreen() {
           </View>
         )}
 
+        {/* ── Ad Banner ───────────────────────────────────────── */}
+        <View style={styles.adContainer}>
+          <AdBanner />
+        </View>
+
         {/* ── Version ─────────────────────────────────────────── */}
         <Text style={styles.versionText}>
           v{Constants.expoConfig?.version ?? '—'}
@@ -622,5 +628,8 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     letterSpacing: 1,
     marginTop: Spacing.sm,
+  },
+  adContainer: {
+    marginTop: Spacing.lg,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ import 'react-native-reanimated';
 
 import '@/constants/i18n'; // Initialize i18next before any component renders
 import AnimatedSplash from '@/components/animated-splash';
+import { useAdsInit } from '@/hooks/use-ads-init';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useDatabase } from '@/hooks/use-database';
 
@@ -17,6 +18,7 @@ export const unstable_settings = {
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const { isReady, error } = useDatabase();
+  useAdsInit();
   const [showingSplash, setShowingSplash] = useState(true);
   const [splashAnimationDone, setSplashAnimationDone] = useState(false);
 

--- a/app/my-words.tsx
+++ b/app/my-words.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { useFocusEffect } from '@react-navigation/native';
 import * as Haptics from 'expo-haptics';
+import { AdBanner } from '@/components/ads/ad-banner';
 import {
   AppColors,
   Layout,
@@ -120,6 +121,13 @@ export default function MyWordsScreen() {
           renderItem={({ item }) => (
             <WordRow word={item} onDelete={() => handleDelete(item)} />
           )}
+          ListFooterComponent={
+            words.length > 0 ? (
+              <View style={styles.adContainer}>
+                <AdBanner />
+              </View>
+            ) : null
+          }
         />
       )}
     </SafeAreaView>
@@ -257,6 +265,9 @@ const styles = StyleSheet.create({
     color: AppColors.textSecondary,
     letterSpacing: 1.5,
     marginBottom: Spacing.md,
+  },
+  adContainer: {
+    marginTop: Spacing.md,
   },
 
   // Word row

--- a/app/quiz.tsx
+++ b/app/quiz.tsx
@@ -7,6 +7,7 @@ import {
   shadowStyleSmall,
 } from '@/constants/design';
 import { useNounTranslation } from '@/hooks/use-noun-translation';
+import { useQuizInterstitialAd } from '@/hooks/use-quiz-interstitial-ad';
 import {
   useQuizSession,
   type QuizMode,
@@ -337,11 +338,19 @@ interface CompleteStateProps {
 function CompleteState({ results, eszettPreference }: CompleteStateProps) {
   const { t } = useTranslation('app');
   const { handleSessionComplete } = useStoreReview();
+  const { maybeShowInterstitial } = useQuizInterstitialAd();
 
   // Request a review once per completed session, when conditions are met
   useEffect(() => {
     handleSessionComplete();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleBackToHome = () => {
+    // Fire-and-forget: the interstitial (if shown) overlays natively, so
+    // navigation doesn't need to wait on it.
+    maybeShowInterstitial();
+    router.back();
+  };
 
   const correctCount = results.filter((r) => r.isCorrect).length;
   const totalCount = results.length;
@@ -418,7 +427,7 @@ function CompleteState({ results, eszettPreference }: CompleteStateProps) {
             styles.backButton,
             pressed && styles.backButtonPressed,
           ]}
-          onPress={() => router.back()}
+          onPress={handleBackToHome}
           accessibilityRole="button"
           accessibilityLabel={t('back_to_home')}
         >

--- a/components/ads/ad-banner.tsx
+++ b/components/ads/ad-banner.tsx
@@ -1,0 +1,50 @@
+import { AD_UNIT_IDS } from '@/constants/ads';
+import { AppColors, Layout, Spacing } from '@/constants/design';
+import { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { BannerAd, BannerAdSize } from 'react-native-google-mobile-ads';
+
+/**
+ * Neo-brutalist bordered banner ad slot.
+ *
+ * Renders nothing until an ad actually loads (and nothing again if it fails
+ * to load, e.g. offline) so a failed/slow fetch never leaves an empty
+ * bordered box on screen.
+ */
+export function AdBanner() {
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [hasFailed, setHasFailed] = useState(false);
+
+  if (hasFailed) return null;
+
+  return (
+    <View style={[styles.container, !hasLoaded && styles.hidden]}>
+      <BannerAd
+        unitId={AD_UNIT_IDS.banner}
+        size={BannerAdSize.LARGE_ANCHORED_ADAPTIVE_BANNER}
+        onAdLoaded={() => setHasLoaded(true)}
+        onAdFailedToLoad={() => setHasFailed(true)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    borderWidth: Layout.borderWidth,
+    borderColor: AppColors.black,
+    backgroundColor: AppColors.white,
+    padding: Spacing.xs,
+  },
+  hidden: {
+    // Ad view still needs to be mounted to load, but stays invisible and
+    // takes up no layout space until it actually has content to show.
+    position: 'absolute',
+    opacity: 0,
+    height: 0,
+    borderWidth: 0,
+    padding: 0,
+    overflow: 'hidden',
+  },
+});

--- a/components/ads/ad-banner.tsx
+++ b/components/ads/ad-banner.tsx
@@ -7,6 +7,10 @@ import { BannerAd, BannerAdSize } from 'react-native-google-mobile-ads';
 /**
  * Neo-brutalist bordered banner ad slot.
  *
+ * Uses a fixed BANNER size (320x50) rather than an adaptive size — adaptive
+ * banners size themselves to the full device width for edge-to-edge
+ * placement, which overflows this app's padded, bordered card layout.
+ *
  * Renders nothing until an ad actually loads (and nothing again if it fails
  * to load, e.g. offline) so a failed/slow fetch never leaves an empty
  * bordered box on screen.
@@ -21,7 +25,7 @@ export function AdBanner() {
     <View style={[styles.container, !hasLoaded && styles.hidden]}>
       <BannerAd
         unitId={AD_UNIT_IDS.banner}
-        size={BannerAdSize.LARGE_ANCHORED_ADAPTIVE_BANNER}
+        size={BannerAdSize.BANNER}
         onAdLoaded={() => setHasLoaded(true)}
         onAdFailedToLoad={() => setHasFailed(true)}
       />

--- a/components/ads/ad-banner.web.tsx
+++ b/components/ads/ad-banner.web.tsx
@@ -1,0 +1,4 @@
+/** AdMob isn't supported on web; no banner is shown there. */
+export function AdBanner() {
+  return null;
+}

--- a/constants/ads.ts
+++ b/constants/ads.ts
@@ -17,7 +17,7 @@
 import { TestIds } from 'react-native-google-mobile-ads';
 
 export const AD_UNIT_IDS = {
-  banner: process.env.EXPO_PUBLIC_ADMOB_BANNER_UNIT_ID || TestIds.ADAPTIVE_BANNER,
+  banner: process.env.EXPO_PUBLIC_ADMOB_BANNER_UNIT_ID || TestIds.BANNER,
   interstitial:
     process.env.EXPO_PUBLIC_ADMOB_INTERSTITIAL_UNIT_ID || TestIds.INTERSTITIAL,
 } as const;

--- a/constants/ads.ts
+++ b/constants/ads.ts
@@ -1,0 +1,28 @@
+/**
+ * AdMob configuration.
+ *
+ * Falls back to Google's official test ad unit IDs when real ones aren't
+ * configured, so dev/preview builds always show (test) ads instead of
+ * failing to load or accidentally serving real ads before an AdMob
+ * account is fully set up.
+ *
+ * Set these once real AdMob units exist:
+ *   EXPO_PUBLIC_ADMOB_BANNER_UNIT_ID
+ *   EXPO_PUBLIC_ADMOB_INTERSTITIAL_UNIT_ID
+ *
+ * The app IDs themselves (used at build time, not here) are set via
+ * EXPO_PUBLIC_ADMOB_ANDROID_APP_ID / EXPO_PUBLIC_ADMOB_IOS_APP_ID in
+ * app.config.js.
+ */
+import { TestIds } from 'react-native-google-mobile-ads';
+
+export const AD_UNIT_IDS = {
+  banner: process.env.EXPO_PUBLIC_ADMOB_BANNER_UNIT_ID || TestIds.ADAPTIVE_BANNER,
+  interstitial:
+    process.env.EXPO_PUBLIC_ADMOB_INTERSTITIAL_UNIT_ID || TestIds.INTERSTITIAL,
+} as const;
+
+export const AD_CONFIG = {
+  /** Show an interstitial only every Nth completed quiz session. */
+  INTERSTITIAL_SESSION_INTERVAL: 3,
+} as const;

--- a/hooks/use-ads-init.ts
+++ b/hooks/use-ads-init.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+/**
+ * Initializes the Google Mobile Ads SDK once at app startup.
+ *
+ * AdMob's native SDK isn't available on web, so this is a no-op there.
+ * Init failures (e.g. no network on first launch) are swallowed — ads are
+ * a monetization add-on and must never block the app from starting.
+ */
+export function useAdsInit() {
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+
+    import('react-native-google-mobile-ads')
+      .then(({ default: mobileAds }) => mobileAds().initialize())
+      .catch((error) => {
+        console.warn('[Ads] Failed to initialize Mobile Ads SDK:', error);
+      });
+  }, []);
+}

--- a/hooks/use-quiz-interstitial-ad.ts
+++ b/hooks/use-quiz-interstitial-ad.ts
@@ -1,0 +1,48 @@
+import { AD_CONFIG, AD_UNIT_IDS } from '@/constants/ads';
+import { settingsService } from '@/services/settingsService';
+import { useCallback, useEffect } from 'react';
+import { useInterstitialAd } from 'react-native-google-mobile-ads';
+
+/**
+ * Preloads an interstitial ad and shows it between quiz sessions — never
+ * mid-quiz. Capped to every Nth completed session (AD_CONFIG) so ads don't
+ * interrupt every single review.
+ *
+ * Call `maybeShowInterstitial()` once, right when a session ends (e.g. the
+ * "back to home" tap on the results screen). It no-ops silently on any
+ * failure — ads must never block navigation.
+ */
+export function useQuizInterstitialAd() {
+  const { isLoaded, isClosed, load, show } = useInterstitialAd(
+    AD_UNIT_IDS.interstitial,
+  );
+
+  // Preload on mount.
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Preload the next ad once the current one has been dismissed.
+  useEffect(() => {
+    if (isClosed) load();
+  }, [isClosed, load]);
+
+  const maybeShowInterstitial = useCallback(async () => {
+    try {
+      const count =
+        (await settingsService.getInterstitialSessionCount()) + 1;
+
+      if (count < AD_CONFIG.INTERSTITIAL_SESSION_INTERVAL) {
+        await settingsService.setInterstitialSessionCount(count);
+        return;
+      }
+
+      await settingsService.setInterstitialSessionCount(0);
+      if (isLoaded) show();
+    } catch (error) {
+      console.warn('[Ads] Failed to show interstitial:', error);
+    }
+  }, [isLoaded, show]);
+
+  return { maybeShowInterstitial };
+}

--- a/hooks/use-quiz-interstitial-ad.web.ts
+++ b/hooks/use-quiz-interstitial-ad.web.ts
@@ -1,0 +1,5 @@
+/** AdMob isn't supported on web; quiz sessions there never show an interstitial. */
+export function useQuizInterstitialAd() {
+  const maybeShowInterstitial = async () => {};
+  return { maybeShowInterstitial };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-i18next": "^16.5.4",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-google-mobile-ads": "^16.4.0",
         "react-native-keyboard-controller": "1.18.5",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -2329,6 +2330,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@iabtcf/core": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@iabtcf/core/-/core-1.5.6.tgz",
+      "integrity": "sha512-u2q9thI9vLurYZdGtyJsDYOqoeLc4EgQsYGSc+UVibYII61B/ENJPZS6eFlML1F0hSoTR/goptpo5nGRDkKd2w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
@@ -5844,6 +5851,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -12590,6 +12606,24 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-google-mobile-ads": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-google-mobile-ads/-/react-native-google-mobile-ads-16.4.0.tgz",
+      "integrity": "sha512-I+H9huEO30XaNZ4InPLCZS2DsnbegGjWqFavJMFssDnm78OPJkAOodY6OSCsEtonq0pdG2YbhchhIuZmE427Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@iabtcf/core": "^1.5.6",
+        "use-deep-compare-effect": "^1.8.1"
+      },
+      "peerDependencies": {
+        "expo": ">=47.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
@@ -14734,6 +14768,23 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13"
       }
     },
     "node_modules/use-latest-callback": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-i18next": "^16.5.4",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-google-mobile-ads": "^16.4.0",
     "react-native-keyboard-controller": "1.18.5",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "üben",
   "main": "expo-router/entry",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/services/settingsService.ts
+++ b/services/settingsService.ts
@@ -11,6 +11,7 @@ export const SETTINGS_KEYS = {
   APP_LANGUAGE: 'app_language',
   QUIZ_SESSIONS_COMPLETED: 'quiz_sessions_completed',
   LAST_REVIEW_REQUEST_DATE: 'last_review_request_date',
+  INTERSTITIAL_SESSION_COUNT: 'interstitial_session_count',
 } as const;
 
 // ── Settings Service ──────────────────────────────────────────────────
@@ -120,6 +121,21 @@ class SettingsService {
 
   async setAppLanguage(language: 'en' | 'it' | 'pl'): Promise<void> {
     await this.setSetting(SETTINGS_KEYS.APP_LANGUAGE, language);
+  }
+
+  // ── Convenience: Interstitial Ad Session Count ────────────────────
+
+  /** Number of quiz sessions completed since the last interstitial ad was shown. */
+  async getInterstitialSessionCount(): Promise<number> {
+    const value = await this.getSetting(SETTINGS_KEYS.INTERSTITIAL_SESSION_COUNT);
+    return value ? parseInt(value, 10) : 0;
+  }
+
+  async setInterstitialSessionCount(count: number): Promise<void> {
+    await this.setSetting(
+      SETTINGS_KEYS.INTERSTITIAL_SESSION_COUNT,
+      String(count),
+    );
   }
 
 }


### PR DESCRIPTION
## Summary

Integrate AdMob to display banner and interstitial ads in the app. Banner ads appear on the Progress and My Words screens, while interstitial ads show after every third completed quiz session.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Database / migration change
- [ ] Dependency update
- [ ] Docs / config only

## Related Issue

Closes #

## Changes

- Added AdMob banner and interstitial ads using `react-native-google-mobile-ads`.
- Moved banner ad from Settings to Progress for better visibility.
- Fixed banner ad overflow issue by using a fixed size.
- Implemented logic to show interstitial ads after every third quiz session.

## Testing

- [ ] Tested on iOS
- [ ] Tested on Android
- [ ] Tested edge cases (e.g. empty state, offline, 0 due cards)
- [ ] SQLite operations verified (no web-platform usage)
- [ ] New/updated database migrations tested from a clean state

## Screenshots

<!-- For UI changes, include before/after screenshots. Delete this section if not applicable. -->

| Before | After |
|--------|-------|
|        |       |

## Checklist

- [ ] `npm run lint` passes
- [ ] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] No inline styles — all styles use `StyleSheet.create()`
- [ ] No SQL string interpolation — all queries use prepared statements
- [ ] No `console.log` left in production paths
- [ ] Components stay under 200 lines
- [ ] Business logic is in the service layer, not in components

